### PR TITLE
:green_heart: fix CI build

### DIFF
--- a/.tekton/automated-actions-cli-main-push.yaml
+++ b/.tekton/automated-actions-cli-main-push.yaml
@@ -26,8 +26,6 @@ spec:
     value: Dockerfile.cli
   - name: path-context
     value: ./
-  - name: image-expires-after
-    value: 1d
   - name: target-stage
     value: pypi
   - name: additional_secret

--- a/.tekton/automated-actions-client-main-push.yaml
+++ b/.tekton/automated-actions-client-main-push.yaml
@@ -26,8 +26,6 @@ spec:
     value: Dockerfile.client
   - name: path-context
     value: ./
-  - name: image-expires-after
-    value: 1d
   - name: target-stage
     value: pypi
   - name: additional_secret


### PR DESCRIPTION
`image-expires-after` isn't allowed for releases.