### PR TITLE
Always run all components pipeline runs

### DIFF
--- a/.tekton/automated-actions-cli-main-pull-request.yaml
+++ b/.tekton/automated-actions-cli-main-pull-request.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "10"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main" && files.all.exists(x, x.matches('automated_actions_cli/|.tekton/automated-actions-cli-main-pull-request.yaml|.tekton/automated-actions-cli-main-push.yaml'))
+      == "main"
   labels:
     appstudio.openshift.io/application: automated-actions-main
     appstudio.openshift.io/component: automated-actions-cli-main

--- a/.tekton/automated-actions-cli-main-push.yaml
+++ b/.tekton/automated-actions-cli-main-push.yaml
@@ -7,7 +7,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "10"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main" && files.all.exists(x, x.matches('automated_actions_cli/|.tekton/automated-actions-cli-main-pull-request.yaml|.tekton/automated-actions-cli-main-push.yaml'))
+      == "main"
   labels:
     appstudio.openshift.io/application: automated-actions-main
     appstudio.openshift.io/component: automated-actions-cli-main

--- a/.tekton/automated-actions-client-main-pull-request.yaml
+++ b/.tekton/automated-actions-client-main-pull-request.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "10"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main" && files.all.exists(x, x.matches('automated_actions_client/|.tekton/automated-actions-client-main-pull-request.yaml|.tekton/automated-actions-client-main-push.yaml'))
+      == "main"
   labels:
     appstudio.openshift.io/application: automated-actions-main
     appstudio.openshift.io/component: automated-actions-client-main

--- a/.tekton/automated-actions-client-main-push.yaml
+++ b/.tekton/automated-actions-client-main-push.yaml
@@ -7,7 +7,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "10"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main" && files.all.exists(x, x.matches('automated_actions_client/|.tekton/automated-actions-client-main-pull-request.yaml|.tekton/automated-actions-client-main-push.yaml'))
+      == "main"
   labels:
     appstudio.openshift.io/application: automated-actions-main
     appstudio.openshift.io/component: automated-actions-client-main


### PR DESCRIPTION
To avoid having old snapshots that can make EC checks fail.