### PR TITLE
:bug: [integration-tests] fix OpenShift template

### DIFF
--- a/openshift/integration-tests.yaml
+++ b/openshift/integration-tests.yaml
@@ -52,6 +52,11 @@ parameters:
   value: ''
   required: true
 
+- name: IMAGE_PULL_SECRETS
+  description: Pull secrets to use for automated-actions images
+  value: '[]'
+  required: false
+
 - name: SERVICE_ACCOUNT
   description: name of the service account to use when deploying the pod
   value: "integration-tests"


### PR DESCRIPTION
Add missing `IMAGE_PULL_SECRETS` variable.

```
  File "/work/reconcile/utils/openshift_resource.py", line 451, in <listcomp>
    if "-dockercfg-" not in s["name"]
                            ~^^^^^^^^
TypeError: string indices must be integers, not 'str'
```