### PR TITLE
:bug: [integration-tests] fix permission errors

### DIFF
--- a/Dockerfile.integration_tests
+++ b/Dockerfile.integration_tests
@@ -18,8 +18,7 @@ ENV \
     PROMPT_COMMAND=". ${APP_ROOT}/bin/activate"
 
 # Install base dependencies
-RUN microdnf install -y python3.12 make && microdnf clean all
-USER 1001
+RUN microdnf install -y python3.12 make findutils && microdnf clean all
 WORKDIR ${APP_ROOT}/src
 
 
@@ -37,9 +36,12 @@ ENV \
     # disable uv cache. it doesn't make sense in a container
     UV_NO_CACHE=true
 
-COPY --chown=1001:0 pyproject.toml uv.lock ./
+# I don't want to mess with permission issues in the builder image. We use a non-root user in the final images
+USER 0
+
+COPY pyproject.toml uv.lock ./
 # automated_actions_client is a dependency of automated_actions_cli
-COPY --chown=1001:0 packages/automated_actions_client ./packages/automated_actions_client
+COPY packages/automated_actions_client ./packages/automated_actions_client
 COPY packages/automated_actions_cli ./packages/automated_actions_cli
 
 COPY packages/integration_tests/ ./packages/integration_tests/
@@ -51,8 +53,12 @@ RUN cd ./packages/integration_tests/ && uv sync
 #
 FROM base AS test
 
-COPY --from=builder --chown=1001:0 /opt/app-root /opt/app-root
+COPY --from=builder /opt/app-root /opt/app-root
 COPY packages/integration_tests/Makefile ./packages/integration_tests/
+
+RUN find ${APP_ROOT} -type d -exec chmod 777 {} \;
+USER 1001
+
 RUN make -C packages/integration_tests test
 
 
@@ -60,7 +66,10 @@ RUN make -C packages/integration_tests test
 # Production image
 #
 FROM base AS prod
-COPY --from=builder --chown=1001:0 /opt/app-root /opt/app-root
+COPY --from=builder /opt/app-root /opt/app-root
+
+RUN find ${APP_ROOT} -type d -exec chmod 777 {} \;
+USER 1001
 
 WORKDIR ${APP_ROOT}/src/packages/integration_tests
 ENTRYPOINT [ "uv", "run", "pytest", "tests" ]


### PR DESCRIPTION
Fix

```
error: failed to remove file `/opt/app-root/lib/python3.12/site-packages/integration_tests-0.1.0.dist-info/INSTALLER`: Permission denied (os error 13)
```