### PR TITLE
[integration-tests] remove obsolete pytest config

### DIFF
--- a/packages/integration_tests/pyproject.toml
+++ b/packages/integration_tests/pyproject.toml
@@ -105,6 +105,3 @@ warn_unused_ignores = true
 show_error_codes = true
 disallow_untyped_defs = true
 disallow_incomplete_defs = true
-
-[tool.pytest.ini_options]
-asyncio_default_fixture_loop_scope = "function"


### PR DESCRIPTION
`pytest-asyncio` isn't used for the integration tests.