### PR TITLE
Set environment variable

### DIFF
--- a/packages/automated_actions/automated_actions/config.py
+++ b/packages/automated_actions/automated_actions/config.py
@@ -9,6 +9,7 @@ class Settings(BaseSettings):
     debug: bool = False
     url: str = "http://localhost:8080"
     root_path: str = ""
+    environment: str
 
     # worker config
     broker_url: str = "sqs://localhost:4566"

--- a/packages/automated_actions/automated_actions/db/models/_action.py
+++ b/packages/automated_actions/automated_actions/db/models/_action.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel, ConfigDict, field_serializer
 from pynamodb.attributes import DynamicMapAttribute, UnicodeAttribute
 from pynamodb.indexes import AllProjection, GlobalSecondaryIndex
 
+from automated_actions.config import settings
 from automated_actions.db.models._base import Table
 
 
@@ -67,7 +68,7 @@ class Action(Table[ActionSchemaIn, ActionSchemaOut]):
     """Action."""
 
     class Meta(Table.Meta):
-        table_name = "aa-action"
+        table_name = f"aa-action-{settings.environment}"
         schema_out = ActionSchemaOut
 
     @staticmethod

--- a/packages/automated_actions/automated_actions/db/models/_user.py
+++ b/packages/automated_actions/automated_actions/db/models/_user.py
@@ -3,6 +3,7 @@ from typing import Self
 from pydantic import BaseModel
 from pynamodb.attributes import ListAttribute, UnicodeAttribute
 
+from automated_actions.config import settings
 from automated_actions.db.models._base import Table
 
 
@@ -22,7 +23,7 @@ class User(Table[UserSchemaIn, UserSchemaOut]):
     """User."""
 
     class Meta(Table.Meta):
-        table_name = "aa-user"
+        table_name = f"aa-user-{settings.environment}"
         schema_out = UserSchemaOut
 
     @classmethod

--- a/packages/automated_actions/tests/conftest.py
+++ b/packages/automated_actions/tests/conftest.py
@@ -9,6 +9,7 @@ from fastapi.testclient import TestClient
 from pydantic import BaseModel, Field
 from pytest_httpx import HTTPXMock
 
+os.environ["AA_ENVIRONMENT"] = "unit_tests"
 os.environ["AA_OIDC_ISSUER"] = "http://dev.com"
 os.environ["AA_OIDC_CLIENT_ID"] = "test_client_id"
 os.environ["AA_OIDC_CLIENT_SECRET"] = "test_client_secret"

--- a/packages/automated_actions/tests/test_config.py
+++ b/packages/automated_actions/tests/test_config.py
@@ -2,4 +2,4 @@ def test_config_import_settings() -> None:
     from automated_actions.config import settings  # noqa: PLC0415
 
     # we don't need to test all settings because ruff and mypy will do that for us
-    assert settings.debug is False
+    assert settings.environment == "unit_tests"


### PR DESCRIPTION
And use it to make sure we create different dynamodb tables per environment in case we use the same AWS account for different accounts.