### PR TITLE
action-list: action_user param 

### DIFF
--- a/packages/automated_actions/automated_actions/api/v1/views/action.py
+++ b/packages/automated_actions/automated_actions/api/v1/views/action.py
@@ -18,11 +18,21 @@ log = logging.getLogger(__name__)
 def action_list(
     user: UserDep,
     action_mgr: Annotated[ActionManager, Depends(get_action_manager)],
-    status: Annotated[ActionStatus | None, Query()] = ActionStatus.RUNNING,
+    status: Annotated[
+        ActionStatus | None, Query(description="Filter actions by their status")
+    ] = None,
+    action_user: Annotated[
+        str | None,
+        Query(
+            description="Filter actions by username instead of the current authenticated user"
+        ),
+    ] = None,
 ) -> list[ActionSchemaOut]:
-    """List all user actions."""
-    status = status or ActionStatus.RUNNING
-    return [action.dump() for action in action_mgr.get_user_actions(user.email, status)]
+    """List actions."""
+    return [
+        action.dump()
+        for action in action_mgr.get_user_actions(action_user or user.username, status)
+    ]
 
 
 @router.get("/actions/{action_id}", operation_id="action-detail")

--- a/packages/automated_actions/automated_actions/api/v1/views/openshift.py
+++ b/packages/automated_actions/automated_actions/api/v1/views/openshift.py
@@ -21,7 +21,7 @@ def get_action(
     action_mgr: Annotated[ActionManager, Depends(get_action_manager)], user: UserDep
 ) -> Action:
     """Get a new action object for the user."""
-    return action_mgr.create_action(name="openshift-workload-restart", owner=user.email)
+    return action_mgr.create_action(name="openshift-workload-restart", owner=user)
 
 
 @router.post(

--- a/packages/automated_actions/automated_actions/auth.py
+++ b/packages/automated_actions/automated_actions/auth.py
@@ -286,8 +286,10 @@ class OPA[UserModel: UserModelProtocol]:
             return
 
         # check if user is authorized to access endpoint
+        params = request.path_params.copy()
+        params.update(request.query_params)
         if not await self.user_is_authorized(
-            user, obj=request["route"].operation_id, params=request.path_params
+            user, obj=request["route"].operation_id, params=params
         ):
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED, detail="Not authorized"

--- a/packages/automated_actions/tests/db/test_model_action.py
+++ b/packages/automated_actions/tests/db/test_model_action.py
@@ -19,8 +19,8 @@ class ActionStub(ActionSchemaOut):
         return self
 
     @classmethod
-    def find_by_owner_and_status(
-        cls, owner_email: str, status: str
+    def find_by_owner(
+        cls, username: str, status: ActionStatus | None
     ) -> list[ActionStub]:
         """Stub method to return a list of actions."""
         return [ACTION]
@@ -75,4 +75,8 @@ def test_model_action_action_manager_get_or_404(action_mgr: ActionManager) -> No
 
 
 def test_model_action_action_manager_create_action(action_mgr: ActionManager) -> None:
-    assert action_mgr.create_action("fake", "owner") == ACTION
+    class User:
+        username = "owner_email"
+
+    owner = User()
+    assert action_mgr.create_action("fake", owner) == ACTION

--- a/packages/automated_actions_cli/automated_actions_cli/formatter.py
+++ b/packages/automated_actions_cli/automated_actions_cli/formatter.py
@@ -1,6 +1,7 @@
 import json
 from collections.abc import Callable
 from enum import StrEnum
+from typing import Any
 
 import yaml
 
@@ -17,7 +18,7 @@ class JsonFormatter:
         self._printer = printer
         self._indent = indent
 
-    def __call__(self, data: dict) -> None:
+    def __call__(self, data: Any) -> None:
         """Format the data as JSON."""
         self._printer(json.dumps(data, indent=self._indent, sort_keys=True))
 
@@ -27,8 +28,14 @@ class YamlFormatter:
         self._printer = printer
         self._indent = indent
 
-    def __call__(self, data: dict) -> None:
+    def __call__(self, data: Any) -> None:
         """Format the data as yaml."""
         self._printer(
-            yaml.dump(data, indent=self._indent, sort_keys=True, explicit_start=True)
+            yaml.dump(
+                data,
+                indent=self._indent,
+                sort_keys=True,
+                explicit_start=True,
+                default_flow_style=False,
+            )
         )

--- a/packages/automated_actions_cli/tests/test_formatter.py
+++ b/packages/automated_actions_cli/tests/test_formatter.py
@@ -9,13 +9,25 @@ def test_formatter_json() -> None:
     formatter({"key": "value"})
 
 
+def test_formatter_json_str() -> None:
+    def check_output(output: str) -> None:
+        assert output == '"testtest"'
+
+    formatter = JsonFormatter(printer=check_output, indent=0)
+    formatter("testtest")
+
+
 def test_formatter_yaml() -> None:
     def check_output(output: str) -> None:
-        assert (
-            output
-            == """---
-key: value\n"""
-        )
+        assert output == "---\nkey: value\n"
 
     formatter = YamlFormatter(printer=check_output, indent=0)
     formatter({"key": "value"})
+
+
+def test_formatter_yaml_string() -> None:
+    def check_output(output: str) -> None:
+        assert output == "--- testtest\n...\n"
+
+    formatter = YamlFormatter(printer=check_output, indent=0)
+    formatter("testtest")

--- a/packages/automated_actions_client/automated_actions_client/api/v1/action_cancel.py
+++ b/packages/automated_actions_client/automated_actions_client/api/v1/action_cancel.py
@@ -181,4 +181,11 @@ def action_cancel(
 ) -> None:
     result = sync(action_id=action_id, client=ctx.obj["client"])
     if "formatter" in ctx.obj and result:
-        ctx.obj["formatter"](result.to_dict() if hasattr(result, "to_dict") else result)
+        output: Any = result
+        if isinstance(result, list):
+            output = [
+                item.to_dict() if hasattr(item, "to_dict") else item for item in result
+            ]
+        elif hasattr(result, "to_dict"):
+            output = result.to_dict()
+        ctx.obj["formatter"](output)

--- a/packages/automated_actions_client/automated_actions_client/api/v1/action_detail.py
+++ b/packages/automated_actions_client/automated_actions_client/api/v1/action_detail.py
@@ -181,4 +181,11 @@ def action_detail(
 ) -> None:
     result = sync(action_id=action_id, client=ctx.obj["client"])
     if "formatter" in ctx.obj and result:
-        ctx.obj["formatter"](result.to_dict() if hasattr(result, "to_dict") else result)
+        output: Any = result
+        if isinstance(result, list):
+            output = [
+                item.to_dict() if hasattr(item, "to_dict") else item for item in result
+            ]
+        elif hasattr(result, "to_dict"):
+            output = result.to_dict()
+        ctx.obj["formatter"](output)

--- a/packages/automated_actions_client/automated_actions_client/api/v1/create_token.py
+++ b/packages/automated_actions_client/automated_actions_client/api/v1/create_token.py
@@ -201,4 +201,11 @@ def create_token(
         client=ctx.obj["client"],
     )
     if "formatter" in ctx.obj and result:
-        ctx.obj["formatter"](result.to_dict() if hasattr(result, "to_dict") else result)
+        output: Any = result
+        if isinstance(result, list):
+            output = [
+                item.to_dict() if hasattr(item, "to_dict") else item for item in result
+            ]
+        elif hasattr(result, "to_dict"):
+            output = result.to_dict()
+        ctx.obj["formatter"](output)

--- a/packages/automated_actions_client/automated_actions_client/api/v1/me.py
+++ b/packages/automated_actions_client/automated_actions_client/api/v1/me.py
@@ -149,4 +149,11 @@ def me(
 ) -> None:
     result = sync(client=ctx.obj["client"])
     if "formatter" in ctx.obj and result:
-        ctx.obj["formatter"](result.to_dict() if hasattr(result, "to_dict") else result)
+        output: Any = result
+        if isinstance(result, list):
+            output = [
+                item.to_dict() if hasattr(item, "to_dict") else item for item in result
+            ]
+        elif hasattr(result, "to_dict"):
+            output = result.to_dict()
+        ctx.obj["formatter"](output)

--- a/packages/automated_actions_client/automated_actions_client/api/v1/openshift_workload_restart.py
+++ b/packages/automated_actions_client/automated_actions_client/api/v1/openshift_workload_restart.py
@@ -241,4 +241,11 @@ def openshift_workload_restart(
         client=ctx.obj["client"],
     )
     if "formatter" in ctx.obj and result:
-        ctx.obj["formatter"](result.to_dict() if hasattr(result, "to_dict") else result)
+        output: Any = result
+        if isinstance(result, list):
+            output = [
+                item.to_dict() if hasattr(item, "to_dict") else item for item in result
+            ]
+        elif hasattr(result, "to_dict"):
+            output = result.to_dict()
+        ctx.obj["formatter"](output)

--- a/packages/automated_actions_client/openapi_python_client_templates/typer_command.py.jinja
+++ b/packages/automated_actions_client/openapi_python_client_templates/typer_command.py.jinja
@@ -65,5 +65,13 @@ def {{endpoint.name | replace("-", "_") }}(
         client=ctx.obj["client"]
     )
     if "formatter" in ctx.obj and result:
-        ctx.obj["formatter"](result.to_dict() if hasattr(result, "to_dict") else result)
+        output: Any = result
+        if isinstance(result, list):
+            output = [
+                item.to_dict() if hasattr(item, "to_dict") else item for item in result
+            ]
+        elif hasattr(result, "to_dict"):
+            output = result.to_dict()
+        ctx.obj["formatter"](output)
+
 {% endif %}

--- a/packages/opa/Makefile
+++ b/packages/opa/Makefile
@@ -1,3 +1,3 @@
 .PHONY: test
 test:
-	# opa test -v authz tests
+	opa test -v authz tests

--- a/packages/opa/authz/default_roles.yml
+++ b/packages/opa/authz/default_roles.yml
@@ -7,7 +7,8 @@ roles:
   - obj: me
     params: {}
   - obj: action-list
-    params: {}
+    params:
+      action_user: null
   - obj: action-detail
     params: {}
   - obj: action-cancel

--- a/packages/opa/authz/rbac.rego
+++ b/packages/opa/authz/rbac.rego
@@ -35,7 +35,15 @@ object_matches(permission_obj, input_obj) if {
 }
 
 valid_params(expected, provided) if {
-	every k, v in expected {
-		regex.match(sprintf("(?i)%s", [v]), provided[k])
+	# Check that null values in expected mean that the key should not be present in provided
+	null_keys := {k | expected[k] == null}
+	every k in null_keys {
+		not provided[k]
+	}
+
+	# For non-null values, ensure they match using regex
+	non_null_keys := {k | expected[k] != null}
+	every k in non_null_keys {
+		regex.match(sprintf("(?i)%s", [expected[k]]), provided[k])
 	}
 }

--- a/packages/opa/authz/rbac_default_roles_test.rego
+++ b/packages/opa/authz/rbac_default_roles_test.rego
@@ -18,6 +18,14 @@ test_default_action_list if {
 	}
 }
 
+test_default_action_list_action_user_param_not_allowed if {
+	not authz.allow with input as {
+		"username": "random-user",
+		"obj": "action-list",
+		"params": {"action_user": "some-user"},
+	}
+}
+
 test_default_action_detail if {
 	authz.allow with input as {
 		"username": "random-user",

--- a/uv.lock
+++ b/uv.lock
@@ -177,7 +177,7 @@ dev = [
     { name = "pytest", specifier = "==8.3.5" },
     { name = "pytest-cov", specifier = "==6.1.1" },
     { name = "ruff", specifier = "==0.11.8" },
-    { name = "types-pyyaml", specifier = ">=6.0.12.20250402" },
+    { name = "types-pyyaml", specifier = "==6.0.12.20250402" },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR refactors the `action-list` endpoint:

1. **:passport_control: [opa] support authorization on query params**

The default roles don't allow the usage of `action_user` for `action-list`

2. **:sparkles: [automated-actions] action-list supports action_user param**

Support listing action for `action_user` and make `status` an optional parameter. The default is to list all actions for the currently logged-in user.

**Breaking change**

We use `username` instead of `email` for `action.owner`. 

**Others**

Additionally, this PR fixes the CLI formatter for list responses.


Prerequisite for https://issues.redhat.com/browse/APPSRE-12021