### PR TITLE
authorization fixes

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -138,7 +138,7 @@ objects:
     name: automated-actions
   spec:
     ports:
-    - name: "8000"
+    - name: "http"
       port: ${{AA_APP_PORT}}
       targetPort: ${{AA_APP_PORT}}
     selector:
@@ -249,7 +249,7 @@ objects:
     name: automated-actions-worker
   spec:
     ports:
-    - name: "8000"
+    - name: "http"
       port: ${{AA_WORKER_METRICS_PORT}}
       targetPort: ${{AA_WORKER_METRICS_PORT}}
     selector:

--- a/packages/automated_actions/automated_actions/api/__init__.py
+++ b/packages/automated_actions/automated_actions/api/__init__.py
@@ -40,7 +40,7 @@ async def initialize_auth_components(app: FastAPI) -> None:
         issuer=settings.url, secret=settings.token_secret, user_model=User
     )
     app.state.authz = OPA[User](  # type: ignore[type-var]
-        opa_host=settings.opa_host, package_name="authz", skip_endpoints=["/api/v1/me"]
+        opa_host=settings.opa_host, package_name="authz", skip_endpoints=[]
     )
     log.info("Auth components initialized.")
 

--- a/packages/opa/authz/rate_limit.rego
+++ b/packages/opa/authz/rate_limit.rego
@@ -38,6 +38,9 @@ max_ops_limit_not_exceeded(current_obj, max_ops, username) if {
 	not is_number(max_ops)
 }
 
+# max_ops == 0 means no limit
+max_ops_limit_not_exceeded(_, 0, _) := true
+
 # Check if the max_ops limit is not exceeded for the given action and user.
 max_ops_limit_not_exceeded(current_obj, max_ops, username) if {
 	is_number(max_ops)

--- a/packages/opa/authz/rate_limit_test.rego
+++ b/packages/opa/authz/rate_limit_test.rego
@@ -7,6 +7,7 @@ _test_users_max_ops := {
 	"user_admin_max_ops": ["role_admin_max_ops_2"],
 	"user_no_max_ops_def": ["role_no_max_ops_def"],
 	"user_invalid_max_ops_type": ["role_max_ops_invalid_type"],
+	"user_max_ops_zero": ["role_max_ops_zero"],
 }
 
 _test_roles_max_ops := {
@@ -28,6 +29,11 @@ _test_roles_max_ops := {
 	"role_max_ops_invalid_type": [{
 		"obj": "action-invalid-maxops",
 		"max_ops": "not-a-number", # max_ops is not a number
+		"params": {},
+	}],
+	"role_max_ops_zero": [{
+		"obj": "action-maxops-zero",
+		"max_ops": 0,
 		"params": {},
 	}],
 }
@@ -198,8 +204,18 @@ test_max_ops_not_a_number_results_in_allowed if {
 	}
 		with data.users as _test_users_max_ops
 		with data.roles as _test_roles_max_ops
-		# No 'with http.send as ...' needed.
-with 		opa.runtime as mock_runtime_with_env
+		with opa.runtime as mock_runtime_with_env
+}
+
+test_max_ops_zero_results_in_allowed if {
+	authz.within_rate_limits with input as {
+		"username": "user_max_ops_zero",
+		"obj": "action-maxops-zero",
+		"params": {},
+	}
+		with data.users as _test_users_max_ops
+		with data.roles as _test_roles_max_ops
+		with opa.runtime as mock_runtime_with_env
 }
 
 # API call to action-list fails


### PR DESCRIPTION
* A `max_ops: 0` also indicates no rate limit on the action.
* do not skip authz for `me`