### PR TITLE
Only AAIT_* env variables in integration tests

### DIFF
--- a/openshift/integration-tests.yaml
+++ b/openshift/integration-tests.yaml
@@ -45,8 +45,8 @@ objects:
             env:
               - name: AAIT_URL
                 value: ${AAIT_URL}
-              - name: AA_TOKEN
-                value: ${AA_TOKEN}
+              - name: AAIT_TOKEN
+                value: ${AAIT_TOKEN}
             envFrom:
             - configMapRef:
                 name: integration-tests-config
@@ -90,7 +90,7 @@ parameters:
   description: URL of the automated-actions instance to test
   required: true
 
-- name: AA_TOKEN
+- name: AAIT_TOKEN
   description: Access token for the automated-actions instance
   required: true
 

--- a/packages/integration_tests/tests/test_cli.py
+++ b/packages/integration_tests/tests/test_cli.py
@@ -1,4 +1,5 @@
 import json
+import os
 from collections.abc import Callable
 from subprocess import CalledProcessError, CompletedProcess, run
 from typing import Literal
@@ -6,14 +7,18 @@ from typing import Literal
 import pytest
 import yaml
 
+from tests.conftest import Config
+
 AACli = Callable[..., CompletedProcess]
 
 
 @pytest.fixture
-def cli() -> AACli:
+def cli(config: Config) -> AACli:
+    os.environ["AA_TOKEN"] = config.token
+
     def _run(output: Literal["json", "yaml"], *args: str) -> CompletedProcess:
         return run(
-            ["automated-actions", "--output", output, *args],
+            ["automated-actions", "--url", str(config.url), "--output", output, *args],
             capture_output=True,
             text=True,
             check=True,


### PR DESCRIPTION
We were currently mixing AA_* and AAIT_* (for the url and the token) and that made things quite confusing