### PR TITLE
fix: quote openshift template value for ARGS

### DIFF
--- a/openshift/integration-tests.yaml
+++ b/openshift/integration-tests.yaml
@@ -100,5 +100,5 @@ parameters:
   required: true
 
 - name: ARGS
-  description: Override dockerfile args. Helpful if we just want to run scpecific tests instead of all (the default)
-  value: ["tests"]
+  description: Override dockerfile args. Helpful if we just want to run specific tests instead of all (the default)
+  value: '["tests"]'


### PR DESCRIPTION
Fix error

```
[2025-06-03 02:15:21] [ERROR] [DRY-RUN] [saasherder.py:_process_template:968] - [saas-automated-actions-test/automated-actions] https://github.com/app-sre/automated-actions/blob/f9675e3a92b3dd5bac0f6101193efc95aee67d33/openshift/integration-tests.yaml: error processing template: [None]: error: failed to read input object (not a Template?): unable to decode "STDIN": json: cannot unmarshal array into Go struct field Parameter.parameters.value of type string
```

https://github.com/app-sre/automated-actions/pull/136