### PR TITLE
:tada: [automated-actions-cli/client] enable PyPI releases

### DIFF
--- a/packages/automated_actions_cli/Makefile
+++ b/packages/automated_actions_cli/Makefile
@@ -10,4 +10,4 @@ test:
 .PHONY: pypi
 pypi:
 	uv build --sdist --wheel --out-dir dist
-	#UV_PUBLISH_TOKEN=$(shell cat /run/secrets/app-sre-pypi-credentials/token) uv publish
+	UV_PUBLISH_TOKEN=$(shell cat /run/secrets/app-sre-pypi-credentials/token) uv publish

--- a/packages/automated_actions_client/Makefile
+++ b/packages/automated_actions_client/Makefile
@@ -10,4 +10,4 @@ test:
 .PHONY: pypi
 pypi:
 	uv build --sdist --wheel --out-dir dist
-	# UV_PUBLISH_TOKEN=$(shell cat /run/secrets/app-sre-pypi-credentials/token) uv publish
+	UV_PUBLISH_TOKEN=$(shell cat /run/secrets/app-sre-pypi-credentials/token) uv publish


### PR DESCRIPTION
Release the `automated-actions-cli` and `automated-actions-client` packages to PyPI.