### PR TITLE
:heavy_plus_sign: [automated-actions-cli] add missing dependency

### DIFF
--- a/packages/automated_actions_cli/pyproject.toml
+++ b/packages/automated_actions_cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "automated-actions-cli"
-version = "0.1.2"
+version = "0.1.3"
 description = "Automated Actions Client"
 authors = [
     # Feel free to add or change authors
@@ -14,6 +14,7 @@ dependencies = [
     "automated-actions-client",
     "diskcache==5.6.3",
     "httpx-gssapi==0.4",
+    "packaging==25.0",
     "pydantic-settings==2.9.1",
     "pyyaml==6.0.2",
     "rich==14.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -134,13 +134,14 @@ dev = [
 
 [[package]]
 name = "automated-actions-cli"
-version = "0.1.1"
+version = "0.1.3"
 source = { editable = "packages/automated_actions_cli" }
 dependencies = [
     { name = "appdirs" },
     { name = "automated-actions-client" },
     { name = "diskcache" },
     { name = "httpx-gssapi" },
+    { name = "packaging" },
     { name = "pydantic-settings" },
     { name = "pyyaml" },
     { name = "rich" },
@@ -162,6 +163,7 @@ requires-dist = [
     { name = "automated-actions-client", editable = "packages/automated_actions_client" },
     { name = "diskcache", specifier = "==5.6.3" },
     { name = "httpx-gssapi", specifier = "==0.4" },
+    { name = "packaging", specifier = "==25.0" },
     { name = "pydantic-settings", specifier = "==2.9.1" },
     { name = "pyyaml", specifier = "==6.0.2" },
     { name = "rich", specifier = "==14.0.0" },
@@ -179,7 +181,7 @@ dev = [
 
 [[package]]
 name = "automated-actions-client"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "packages/automated_actions_client" }
 dependencies = [
     { name = "attrs" },


### PR DESCRIPTION
Fix `ModuleNotFoundError: No module named 'packaging'` for the PyPI package