### PR TITLE
Redistribute action elapsed seconds bucket

### DIFF
--- a/dashboards/metrics-dashboard.yaml
+++ b/dashboards/metrics-dashboard.yaml
@@ -859,7 +859,7 @@ data:
                 "uid": "P7B77307D2CE073BC"
               },
               "editorMode": "code",
-              "expr": "histogram_quantile(0.5, sum by (name, le) (rate(automated_actions_action_elapsed_seconds_bucket{namespace=\"$namespace\"}[60m])))",
+              "expr": "histogram_quantile(0.5, sum by (name, le) (rate(automated_actions_action_elapsed_seconds_bucket{namespace=\"$namespace\"}[10m])))",
               "instant": false,
               "legendFormat": "{{name}}-p50",
               "range": true,
@@ -871,7 +871,7 @@ data:
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "histogram_quantile(0.99, sum by (name, le) (rate(automated_actions_action_elapsed_seconds_bucket{namespace=\"$namespace\"}[60m])))",
+              "expr": "histogram_quantile(0.99, sum by (name, le) (rate(automated_actions_action_elapsed_seconds_bucket{namespace=\"$namespace\"}[10m])))",
               "hide": false,
               "instant": false,
               "legendFormat": "{{name}}-p99",

--- a/packages/automated_actions/automated_actions/celery/metrics.py
+++ b/packages/automated_actions/automated_actions/celery/metrics.py
@@ -8,5 +8,21 @@ action_elapsed_time = Histogram(
     documentation="Elapsed seconds since the moment in the action was inserted in the action table, including retries.",
     labelnames=["name", "status"],
     registry=CELERY_REGISTRY,
-    buckets=(.05, .075, .1, .33, .66, 1.0, 2.0, 4.0, 6.0, 8.0, 10.0, 15.0, 20.0, 30.0, INF)
+    buckets=(
+        0.05,
+        0.075,
+        0.1,
+        0.33,
+        0.66,
+        1.0,
+        2.0,
+        4.0,
+        6.0,
+        8.0,
+        10.0,
+        15.0,
+        20.0,
+        30.0,
+        INF,
+    ),
 )

--- a/packages/automated_actions/automated_actions/celery/metrics.py
+++ b/packages/automated_actions/automated_actions/celery/metrics.py
@@ -1,4 +1,5 @@
 from prometheus_client import CollectorRegistry, Histogram
+from prometheus_client.utils import INF
 
 CELERY_REGISTRY = CollectorRegistry()
 

--- a/packages/automated_actions/automated_actions/celery/metrics.py
+++ b/packages/automated_actions/automated_actions/celery/metrics.py
@@ -7,4 +7,5 @@ action_elapsed_time = Histogram(
     documentation="Elapsed seconds since the moment in the action was inserted in the action table, including retries.",
     labelnames=["name", "status"],
     registry=CELERY_REGISTRY,
+    buckets=(.05, .075, .1, .33, .66, 1.0, 2.0, 4.0, 6.0, 8.0, 10.0, 15.0, 20.0, 30.0, INF)
 )


### PR DESCRIPTION
To better match the actual duration of the action processing.