### PR TITLE
:zap: [automated-actions] avoid unnecessary user updates

### DIFF
--- a/packages/automated_actions/automated_actions/db/models/_user.py
+++ b/packages/automated_actions/automated_actions/db/models/_user.py
@@ -44,7 +44,14 @@ class User(Table[UserSchemaIn, UserSchemaOut]):
             return
         self.update(actions=[User.allowed_actions.set(allowed_actions)])
 
+    # We use the user's email as key because it is unique
+    # and generally available in the OIDC providers.
     email = UnicodeAttribute(hash_key=True)
     name = UnicodeAttribute()
     username = UnicodeAttribute()
+    # The allowed_actions list gets updated via the OPA policy engine
+    # and contains the actions that the user is really allowed to perform.
+    # It's for debugging purposes and to expose the list of actions to the user
+    # via the `me` endpoint.
+    # It is not used for authorization, which is done via OPA policies.
     allowed_actions: ListAttribute = ListAttribute(default=list)


### PR DESCRIPTION
Avoid updating user objects when there are no changes, as we frequently hit the DynamoDB rate limit.