### PR TITLE
[automated-actions-cli] ignore 400 File already exists PyPI errors

### DIFF
--- a/packages/automated_actions_cli/Makefile
+++ b/packages/automated_actions_cli/Makefile
@@ -10,4 +10,4 @@ test:
 .PHONY: pypi
 pypi:
 	uv build --sdist --wheel --out-dir dist
-	UV_PUBLISH_TOKEN=$(shell cat /run/secrets/app-sre-pypi-credentials/token) uv publish
+	UV_PUBLISH_TOKEN=$(shell cat /run/secrets/app-sre-pypi-credentials/token) uv publish || true

--- a/packages/automated_actions_client/Makefile
+++ b/packages/automated_actions_client/Makefile
@@ -10,4 +10,4 @@ test:
 .PHONY: pypi
 pypi:
 	uv build --sdist --wheel --out-dir dist
-	UV_PUBLISH_TOKEN=$(shell cat /run/secrets/app-sre-pypi-credentials/token) uv publish
+	UV_PUBLISH_TOKEN=$(shell cat /run/secrets/app-sre-pypi-credentials/token) uv publish || true


### PR DESCRIPTION
Ignore

```
Uploading automated_actions_cli-0.1.4-py3-none-any.whl (9.3KiB)
error: Failed to publish `dist/automated_actions_cli-0.1.4-py3-none-any.whl` to https://upload.pypi.org/legacy/
  Caused by: Upload failed with status code 400 Bad Request. Server says: 400 File already exists ('automated_actions_cli-0.1.4-py3-none-any.whl', with blake2_256 hash '3fb9bd78fcb9329bcf0ed9b3abed09bd831c050c85ed3014a8e65e12f4f2df62'). See https://pypi.org/help/#file-name-reuse for more information.
make: *** [Makefile:13: pypi] Error 2
```

in case we didn't bump the cli version number.