### PR TITLE
:loud_sound: [automated-actions] action_id in the logs

### DIFF
--- a/packages/automated_actions/automated_actions/celery/app.py
+++ b/packages/automated_actions/automated_actions/celery/app.py
@@ -33,7 +33,7 @@ def setup_loggers(logger: logging.Logger, **_: Any) -> None:
     handler = logging.StreamHandler()
     handler.setFormatter(
         TaskFormatter(
-            "%(asctime)s [%(levelname)s] %(task_name)s: %(message)s action_id=%(task_id)s"
+            "%(asctime)s [%(levelname)s] %(task_name)s action_id=%(task_id)s: %(message)s"
         )
     )
     logger.addHandler(handler)

--- a/packages/automated_actions/automated_actions/celery/app.py
+++ b/packages/automated_actions/automated_actions/celery/app.py
@@ -1,4 +1,8 @@
 import logging
+from typing import Any
+
+from celery.app.log import TaskFormatter as CeleryTaskFormatter
+from celery.signals import after_setup_logger
 
 from automated_actions.config import settings
 from celery import Celery
@@ -7,6 +11,34 @@ from celery import Celery
 logging.getLogger("gql.transport.requests").setLevel(logging.WARNING)
 
 log = logging.getLogger(__name__)
+
+
+class TaskFormatter(CeleryTaskFormatter):
+    """Custom task formatter to include action_id in the log format."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        """Format the log record."""
+        # set default values for task_name and task_id. These will be overridden
+        # by the Celery task name and ID if available.
+        record.task_name = record.name
+        record.task_id = "unknown"
+        return super().format(record)
+
+
+@after_setup_logger.connect
+def setup_loggers(logger: logging.Logger, **_: Any) -> None:
+    """Attach a formatted log handler to the logger."""
+    for handler in logger.handlers:
+        logger.removeHandler(handler)
+    handler = logging.StreamHandler()
+    handler.setFormatter(
+        TaskFormatter(
+            "%(asctime)s [%(levelname)s] %(task_name)s: %(message)s action_id=%(task_id)s"
+        )
+    )
+    logger.addHandler(handler)
+    logger.setLevel(logging.DEBUG if settings.debug else logging.INFO)
+
 
 app = Celery(
     "tasks",

--- a/packages/automated_actions/automated_actions/celery/automated_action_task.py
+++ b/packages/automated_actions/automated_actions/celery/automated_action_task.py
@@ -20,17 +20,17 @@ class AutomatedActionTask(Task):
 
     def before_start(  # noqa: PLR6301
         self,
-        task_id: str,
+        task_id: str,  # noqa: ARG002
         args: tuple,  # noqa: ARG002
         kwargs: dict,
     ) -> None:
         kwargs["action"].set_status(ActionStatus.RUNNING)
-        log.info("action_id=%s status=%s", task_id, ActionStatus.RUNNING)
+        log.info("status=%s", ActionStatus.RUNNING)
 
     def on_success(  # noqa: PLR6301
         self,
         retval: Any,  # noqa: ARG002
-        task_id: str,
+        task_id: str,  # noqa: ARG002
         args: tuple,  # noqa: ARG002
         kwargs: dict,
     ) -> None:
@@ -41,8 +41,7 @@ class AutomatedActionTask(Task):
             task_args=_task_kwargs_to_store(kwargs),
         )
         log.info(
-            "action_id=%s status=%s - %s",
-            task_id,
+            "status=%s - %s",
             ActionStatus.SUCCESS,
             result,
         )
@@ -54,7 +53,7 @@ class AutomatedActionTask(Task):
     def on_failure(  # noqa: PLR6301
         self,
         exc: Exception,
-        task_id: str,
+        task_id: str,  # noqa: ARG002
         args: tuple,  # noqa: ARG002
         kwargs: dict,
         einfo: ExceptionInfo,  # noqa: ARG002
@@ -66,8 +65,7 @@ class AutomatedActionTask(Task):
             task_args=_task_kwargs_to_store(kwargs),
         )
         log.error(
-            "action_id=%s status=%s - %s",
-            task_id,
+            "status=%s - %s",
             ActionStatus.FAILURE,
             result,
         )
@@ -79,12 +77,12 @@ class AutomatedActionTask(Task):
     def on_retry(  # noqa: PLR6301
         self,
         exc: Exception,
-        task_id: str,
+        task_id: str,  # noqa: ARG002
         args: tuple,  # noqa: ARG002
         kwargs: dict,  # noqa: ARG002
         einfo: ExceptionInfo,  # noqa: ARG002
     ) -> None:
-        log.debug("action_id=%s retrying due to %s", task_id, exc)
+        log.debug("retrying due to %s", exc)
 
 
 def _task_kwargs_to_store(kwargs: dict) -> dict:

--- a/packages/automated_actions/automated_actions/celery/openshift/tasks.py
+++ b/packages/automated_actions/automated_actions/celery/openshift/tasks.py
@@ -1,3 +1,5 @@
+import logging
+
 from automated_actions_utils.cluster_connection import get_cluster_connection_data
 from automated_actions_utils.openshift_client import (
     OpenshiftClient,
@@ -8,6 +10,8 @@ from automated_actions.celery.app import app
 from automated_actions.celery.automated_action_task import AutomatedActionTask
 from automated_actions.config import settings
 from automated_actions.db.models import Action
+
+log = logging.getLogger(__name__)
 
 
 class OpenshiftResourceKindNotSupportedError(Exception):
@@ -28,6 +32,9 @@ class OpenshiftWorkloadRestart:
         self.kind = kind
 
     def run(self) -> None:
+        log.info(
+            f"Restarting OpenShift workload {self.kind} {self.name} in namespace {self.namespace}"
+        )
         if self.kind in RollingRestartResource:
             self.oc.rolling_restart(
                 kind=RollingRestartResource(self.kind),


### PR DESCRIPTION
Add the `action_id` automatically to all Celery logs (if available).

Example:

```
2025-06-24 09:26:00,343 [INFO] celery.worker.consumer.connection: Connected to sqs://localstack:4566// action_id=unknown
2025-06-24 09:26:00,417 [INFO] celery.apps.worker: celery@9f219a80164b ready. action_id=unknown
2025-06-24 09:26:15,062 [INFO] celery.worker.strategy: Task automated_actions.celery.openshift.tasks.openshift_workload_restart[b084de65-6ef6-46d1-81fa-90170ba82058] received action_id=unknown
2025-06-24 09:26:15,145 [INFO] automated_actions.celery.openshift.tasks.openshift_workload_restart: status=RUNNING action_id=b084de65-6ef6-46d1-81fa-90170ba82058
2025-06-24 09:26:16,592 [INFO] automated_actions.celery.openshift.tasks.openshift_workload_restart: Restarting OpenShift workload Deployment glitchtip-web in namespace glitchtip-dev action_id=b084de65-6ef6-46d1-81fa-90170ba82058
2025-06-24 09:26:16,611 [INFO] automated_actions.celery.openshift.tasks.openshift_workload_restart: status=SUCCESS - ok action_id=b084de65-6ef6-46d1-81fa-90170ba82058
2025-06-24 09:26:16,613 [INFO] automated_actions.celery.openshift.tasks.openshift_workload_restart: Task automated_actions.celery.openshift.tasks.openshift_workload_restart[b084de65-6ef6-46d1-81fa-90170ba82058] succeeded in 1.5266059569985373s: None action_id=b084de65-6ef6-46d1-81fa-90170ba82058
```

Ticket: [APPSRE-12156](https://issues.redhat.com/browse/APPSRE-12156)