### PR TITLE
:bookmark: [automated-actions-cli/client] bump versions

### DIFF
--- a/packages/automated_actions_cli/pyproject.toml
+++ b/packages/automated_actions_cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "automated-actions-cli"
-version = "0.1.4"
+version = "0.1.5"
 description = "Automated Actions Client"
 authors = [
     # Feel free to add or change authors

--- a/packages/automated_actions_client/pyproject.toml
+++ b/packages/automated_actions_client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "automated-actions-client"
-version = "0.1.3"
+version = "0.1.4"
 description = "Automated Actions Client"
 authors = [{ name = "AppSRE", email = "sd-app-sre@redhat.com" }]
 license = { text = "Apache 2.0" }

--- a/uv.lock
+++ b/uv.lock
@@ -134,7 +134,7 @@ dev = [
 
 [[package]]
 name = "automated-actions-cli"
-version = "0.1.4"
+version = "0.1.5"
 source = { editable = "packages/automated_actions_cli" }
 dependencies = [
     { name = "appdirs" },
@@ -181,7 +181,7 @@ dev = [
 
 [[package]]
 name = "automated-actions-client"
-version = "0.1.3"
+version = "0.1.4"
 source = { editable = "packages/automated_actions_client" }
 dependencies = [
     { name = "attrs" },


### PR DESCRIPTION
Release new versions of `automated-actions-client` and `automated-actions-cli` that include the `external-resource-rds-snapshot` action.