### PR TITLE
fix pypi push

### DIFF
--- a/Dockerfile.cli
+++ b/Dockerfile.cli
@@ -44,5 +44,5 @@ RUN make -C packages/automated_actions_cli test
 FROM test AS pypi
 # Secrets are owned by root and are not readable by others :(
 USER root
-RUN --mount=type=secret,id=app-sre-pypi-credentials/token make -C packages/automated_actions_cli -s pypi
+RUN --mount=type=secret,id=app-sre-pypi-credentials/token,env=UV_PUBLISH_TOKEN make -C packages/automated_actions_cli -s pypi
 USER 1001

--- a/Dockerfile.client
+++ b/Dockerfile.client
@@ -37,5 +37,5 @@ RUN make test
 FROM test AS pypi
 # Secrets are owned by root and are not readable by others :(
 USER root
-RUN --mount=type=secret,id=app-sre-pypi-credentials/token make -s pypi
+RUN --mount=type=secret,id=app-sre-pypi-credentials/token,env=UV_PUBLISH_TOKEN make -s pypi
 USER 1001

--- a/packages/automated_actions_cli/Makefile
+++ b/packages/automated_actions_cli/Makefile
@@ -10,4 +10,4 @@ test:
 .PHONY: pypi
 pypi:
 	uv build --sdist --wheel --out-dir dist
-	UV_PUBLISH_TOKEN=$(shell cat /run/secrets/app-sre-pypi-credentials/token) uv publish || true
+	uv publish || true

--- a/packages/automated_actions_client/Makefile
+++ b/packages/automated_actions_client/Makefile
@@ -10,4 +10,4 @@ test:
 .PHONY: pypi
 pypi:
 	uv build --sdist --wheel --out-dir dist
-	UV_PUBLISH_TOKEN=$(shell cat /run/secrets/app-sre-pypi-credentials/token) uv publish || true
+	uv publish || true


### PR DESCRIPTION
Don't rely on `/run/secrets/app-sre-pypi-credentials/token` on the local development environment.