### PR TITLE
fix pypi push

### DIFF
--- a/Dockerfile.cli
+++ b/Dockerfile.cli
@@ -44,5 +44,5 @@ RUN make -C packages/automated_actions_cli test
 FROM test AS pypi
 # Secrets are owned by root and are not readable by others :(
 USER root
-RUN --mount=type=secret,id=app-sre-pypi-credentials/token UV_PUBLISH_TOKEN=$(cat /run/secrets/app-sre-pypi-credentials/token) make -C packages/automated_actions_cli -s pypi
+RUN --mount=type=secret,id=app-sre-pypi-credentials/token UV_PUBLISH_TOKEN=$(cat /run/secrets/app-sre-pypi-credentials/token) make -C packages/automated_actions_cli pypi
 USER 1001

--- a/Dockerfile.cli
+++ b/Dockerfile.cli
@@ -44,5 +44,5 @@ RUN make -C packages/automated_actions_cli test
 FROM test AS pypi
 # Secrets are owned by root and are not readable by others :(
 USER root
-RUN --mount=type=secret,id=app-sre-pypi-credentials/token,env=UV_PUBLISH_TOKEN make -C packages/automated_actions_cli -s pypi
+RUN --mount=type=secret,id=app-sre-pypi-credentials/token UV_PUBLISH_TOKEN=$(cat /run/secrets/app-sre-pypi-credentials/token) make -C packages/automated_actions_cli -s pypi
 USER 1001

--- a/Dockerfile.client
+++ b/Dockerfile.client
@@ -37,5 +37,5 @@ RUN make test
 FROM test AS pypi
 # Secrets are owned by root and are not readable by others :(
 USER root
-RUN --mount=type=secret,id=app-sre-pypi-credentials/token,env=UV_PUBLISH_TOKEN make -s pypi
+RUN --mount=type=secret,id=app-sre-pypi-credentials/token UV_PUBLISH_TOKEN=$(cat /run/secrets/app-sre-pypi-credentials/token) make -s pypi
 USER 1001

--- a/Dockerfile.client
+++ b/Dockerfile.client
@@ -37,5 +37,5 @@ RUN make test
 FROM test AS pypi
 # Secrets are owned by root and are not readable by others :(
 USER root
-RUN --mount=type=secret,id=app-sre-pypi-credentials/token UV_PUBLISH_TOKEN=$(cat /run/secrets/app-sre-pypi-credentials/token) make -s pypi
+RUN --mount=type=secret,id=app-sre-pypi-credentials/token UV_PUBLISH_TOKEN=$(cat /run/secrets/app-sre-pypi-credentials/token) make pypi
 USER 1001

--- a/packages/automated_actions_cli/Makefile
+++ b/packages/automated_actions_cli/Makefile
@@ -5,8 +5,6 @@ test:
 	uv run mypy
 	uv run pytest -vv --cov=$(notdir $(CURDIR)) --cov-report=term-missing --cov-report xml
 
-# do not print pypi commands to avoid the token leaking to the logs
-.SILENT: pypi
 .PHONY: pypi
 pypi:
 	uv build --sdist --wheel --out-dir dist

--- a/packages/automated_actions_client/Makefile
+++ b/packages/automated_actions_client/Makefile
@@ -5,8 +5,6 @@ test:
 	uv run mypy
 	uv run pytest -vv --cov=$(notdir $(CURDIR)) --cov-report=term-missing --cov-report xml
 
-# do not print pypi commands to avoid the token leaking to the logs
-.SILENT: pypi
 .PHONY: pypi
 pypi:
 	uv build --sdist --wheel --out-dir dist


### PR DESCRIPTION
Unfortunately, [buildah](https://github.com/containers/buildah/issues/5892) doesn't support the `env` option for `RUN --mount=type=secret`. Let's try setting this env variable manually instead.