### PR TITLE
:arrow_up: upgrade openapi-python-client

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -106,9 +106,9 @@ services:
       - dont-start-automatically
     entrypoint:
       - uv
+      - tool
       - run
-      - --frozen
-      - openapi-python-client
+      - openapi-python-client==0.26.2
     command:
       - generate
       - --url=http://automated-actions:8080/docs/openapi.json

--- a/packages/automated_actions_client/automated_actions_client/api/actions/external_resource_flush_elasticache.py
+++ b/packages/automated_actions_client/automated_actions_client/api/actions/external_resource_flush_elasticache.py
@@ -32,10 +32,12 @@ def _parse_response(
         response_202 = ActionSchemaOut.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 422:
         response_422 = HTTPValidationError.from_dict(response.json())
 
         return response_422
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:
@@ -82,10 +84,9 @@ def sync_detailed(
         identifier=identifier,
     )
 
-    with client as _client:
-        response = _client.request(
-            **kwargs,
-        )
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
 
     return _build_response(client=client, response=response)
 
@@ -150,10 +151,7 @@ async def asyncio_detailed(
         identifier=identifier,
     )
 
-    async with client as _client:
-        response = await _client.request(
-            **kwargs,
-        )
+    response = await client.get_async_httpx_client().request(**kwargs)
 
     return _build_response(client=client, response=response)
 

--- a/packages/automated_actions_client/automated_actions_client/api/actions/external_resource_rds_reboot.py
+++ b/packages/automated_actions_client/automated_actions_client/api/actions/external_resource_rds_reboot.py
@@ -41,10 +41,12 @@ def _parse_response(
         response_202 = ActionSchemaOut.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 422:
         response_422 = HTTPValidationError.from_dict(response.json())
 
         return response_422
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:
@@ -95,10 +97,9 @@ def sync_detailed(
         force_failover=force_failover,
     )
 
-    with client as _client:
-        response = _client.request(
-            **kwargs,
-        )
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
 
     return _build_response(client=client, response=response)
 
@@ -171,10 +172,7 @@ async def asyncio_detailed(
         force_failover=force_failover,
     )
 
-    async with client as _client:
-        response = await _client.request(
-            **kwargs,
-        )
+    response = await client.get_async_httpx_client().request(**kwargs)
 
     return _build_response(client=client, response=response)
 

--- a/packages/automated_actions_client/automated_actions_client/api/actions/external_resource_rds_snapshot.py
+++ b/packages/automated_actions_client/automated_actions_client/api/actions/external_resource_rds_snapshot.py
@@ -33,10 +33,12 @@ def _parse_response(
         response_202 = ActionSchemaOut.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 422:
         response_422 = HTTPValidationError.from_dict(response.json())
 
         return response_422
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:
@@ -86,10 +88,9 @@ def sync_detailed(
         snapshot_identifier=snapshot_identifier,
     )
 
-    with client as _client:
-        response = _client.request(
-            **kwargs,
-        )
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
 
     return _build_response(client=client, response=response)
 
@@ -160,10 +161,7 @@ async def asyncio_detailed(
         snapshot_identifier=snapshot_identifier,
     )
 
-    async with client as _client:
-        response = await _client.request(
-            **kwargs,
-        )
+    response = await client.get_async_httpx_client().request(**kwargs)
 
     return _build_response(client=client, response=response)
 

--- a/packages/automated_actions_client/automated_actions_client/api/actions/no_op.py
+++ b/packages/automated_actions_client/automated_actions_client/api/actions/no_op.py
@@ -28,6 +28,7 @@ def _parse_response(
         response_202 = ActionSchemaOut.from_dict(response.json())
 
         return response_202
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:
@@ -65,10 +66,9 @@ def sync_detailed(
 
     kwargs = _get_kwargs()
 
-    with client as _client:
-        response = _client.request(
-            **kwargs,
-        )
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
 
     return _build_response(client=client, response=response)
 
@@ -116,10 +116,7 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs()
 
-    async with client as _client:
-        response = await _client.request(
-            **kwargs,
-        )
+    response = await client.get_async_httpx_client().request(**kwargs)
 
     return _build_response(client=client, response=response)
 

--- a/packages/automated_actions_client/automated_actions_client/api/actions/openshift_workload_delete.py
+++ b/packages/automated_actions_client/automated_actions_client/api/actions/openshift_workload_delete.py
@@ -43,10 +43,12 @@ def _parse_response(
         response_202 = ActionSchemaOut.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 422:
         response_422 = HTTPValidationError.from_dict(response.json())
 
         return response_422
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:
@@ -103,10 +105,9 @@ def sync_detailed(
         api_version=api_version,
     )
 
-    with client as _client:
-        response = _client.request(
-            **kwargs,
-        )
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
 
     return _build_response(client=client, response=response)
 
@@ -191,10 +192,7 @@ async def asyncio_detailed(
         api_version=api_version,
     )
 
-    async with client as _client:
-        response = await _client.request(
-            **kwargs,
-        )
+    response = await client.get_async_httpx_client().request(**kwargs)
 
     return _build_response(client=client, response=response)
 

--- a/packages/automated_actions_client/automated_actions_client/api/actions/openshift_workload_restart.py
+++ b/packages/automated_actions_client/automated_actions_client/api/actions/openshift_workload_restart.py
@@ -35,10 +35,12 @@ def _parse_response(
         response_202 = ActionSchemaOut.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 422:
         response_422 = HTTPValidationError.from_dict(response.json())
 
         return response_422
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:
@@ -92,10 +94,9 @@ def sync_detailed(
         name=name,
     )
 
-    with client as _client:
-        response = _client.request(
-            **kwargs,
-        )
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
 
     return _build_response(client=client, response=response)
 
@@ -174,10 +175,7 @@ async def asyncio_detailed(
         name=name,
     )
 
-    async with client as _client:
-        response = await _client.request(
-            **kwargs,
-        )
+    response = await client.get_async_httpx_client().request(**kwargs)
 
     return _build_response(client=client, response=response)
 

--- a/packages/automated_actions_client/automated_actions_client/api/admin/create_token.py
+++ b/packages/automated_actions_client/automated_actions_client/api/admin/create_token.py
@@ -24,9 +24,8 @@ def _get_kwargs(
         "url": "/api/v1/admin/token",
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -39,10 +38,12 @@ def _parse_response(
     if response.status_code == 200:
         response_200 = cast(str, response.json())
         return response_200
+
     if response.status_code == 422:
         response_422 = HTTPValidationError.from_dict(response.json())
 
         return response_422
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:
@@ -84,10 +85,9 @@ def sync_detailed(
         body=body,
     )
 
-    with client as _client:
-        response = _client.request(
-            **kwargs,
-        )
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
 
     return _build_response(client=client, response=response)
 
@@ -142,10 +142,7 @@ async def asyncio_detailed(
         body=body,
     )
 
-    async with client as _client:
-        response = await _client.request(
-            **kwargs,
-        )
+    response = await client.get_async_httpx_client().request(**kwargs)
 
     return _build_response(client=client, response=response)
 

--- a/packages/automated_actions_client/automated_actions_client/api/general/action_cancel.py
+++ b/packages/automated_actions_client/automated_actions_client/api/general/action_cancel.py
@@ -31,10 +31,12 @@ def _parse_response(
         response_202 = ActionSchemaOut.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 422:
         response_422 = HTTPValidationError.from_dict(response.json())
 
         return response_422
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:
@@ -76,10 +78,9 @@ def sync_detailed(
         action_id=action_id,
     )
 
-    with client as _client:
-        response = _client.request(
-            **kwargs,
-        )
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
 
     return _build_response(client=client, response=response)
 
@@ -134,10 +135,7 @@ async def asyncio_detailed(
         action_id=action_id,
     )
 
-    async with client as _client:
-        response = await _client.request(
-            **kwargs,
-        )
+    response = await client.get_async_httpx_client().request(**kwargs)
 
     return _build_response(client=client, response=response)
 

--- a/packages/automated_actions_client/automated_actions_client/api/general/action_detail.py
+++ b/packages/automated_actions_client/automated_actions_client/api/general/action_detail.py
@@ -31,10 +31,12 @@ def _parse_response(
         response_200 = ActionSchemaOut.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 422:
         response_422 = HTTPValidationError.from_dict(response.json())
 
         return response_422
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:
@@ -76,10 +78,9 @@ def sync_detailed(
         action_id=action_id,
     )
 
-    with client as _client:
-        response = _client.request(
-            **kwargs,
-        )
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
 
     return _build_response(client=client, response=response)
 
@@ -134,10 +135,7 @@ async def asyncio_detailed(
         action_id=action_id,
     )
 
-    async with client as _client:
-        response = await _client.request(
-            **kwargs,
-        )
+    response = await client.get_async_httpx_client().request(**kwargs)
 
     return _build_response(client=client, response=response)
 

--- a/packages/automated_actions_client/automated_actions_client/api/general/action_list.py
+++ b/packages/automated_actions_client/automated_actions_client/api/general/action_list.py
@@ -68,10 +68,12 @@ def _parse_response(
             response_200.append(response_200_item)
 
         return response_200
+
     if response.status_code == 422:
         response_422 = HTTPValidationError.from_dict(response.json())
 
         return response_422
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:
@@ -121,10 +123,9 @@ def sync_detailed(
         max_age_minutes=max_age_minutes,
     )
 
-    with client as _client:
-        response = _client.request(
-            **kwargs,
-        )
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
 
     return _build_response(client=client, response=response)
 
@@ -195,10 +196,7 @@ async def asyncio_detailed(
         max_age_minutes=max_age_minutes,
     )
 
-    async with client as _client:
-        response = await _client.request(
-            **kwargs,
-        )
+    response = await client.get_async_httpx_client().request(**kwargs)
 
     return _build_response(client=client, response=response)
 

--- a/packages/automated_actions_client/automated_actions_client/api/general/me.py
+++ b/packages/automated_actions_client/automated_actions_client/api/general/me.py
@@ -28,6 +28,7 @@ def _parse_response(
         response_200 = UserSchemaOut.from_dict(response.json())
 
         return response_200
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:
@@ -63,10 +64,9 @@ def sync_detailed(
 
     kwargs = _get_kwargs()
 
-    with client as _client:
-        response = _client.request(
-            **kwargs,
-        )
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
 
     return _build_response(client=client, response=response)
 
@@ -110,10 +110,7 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs()
 
-    async with client as _client:
-        response = await _client.request(
-            **kwargs,
-        )
+    response = await client.get_async_httpx_client().request(**kwargs)
 
     return _build_response(client=client, response=response)
 

--- a/packages/automated_actions_client/automated_actions_client/models/action_schema_out.py
+++ b/packages/automated_actions_client/automated_actions_client/models/action_schema_out.py
@@ -1,5 +1,11 @@
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    TypeVar,
+    Union,
+    cast,
+)
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field

--- a/packages/automated_actions_client/automated_actions_client/models/create_token_param.py
+++ b/packages/automated_actions_client/automated_actions_client/models/create_token_param.py
@@ -1,6 +1,9 @@
 import datetime
 from collections.abc import Mapping
-from typing import Any, TypeVar
+from typing import (
+    Any,
+    TypeVar,
+)
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field

--- a/packages/automated_actions_client/automated_actions_client/models/http_validation_error.py
+++ b/packages/automated_actions_client/automated_actions_client/models/http_validation_error.py
@@ -1,5 +1,9 @@
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    TypeVar,
+)
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field

--- a/packages/automated_actions_client/automated_actions_client/models/user_schema_out.py
+++ b/packages/automated_actions_client/automated_actions_client/models/user_schema_out.py
@@ -1,5 +1,9 @@
 from collections.abc import Mapping
-from typing import Any, TypeVar, cast
+from typing import (
+    Any,
+    TypeVar,
+    cast,
+)
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field

--- a/packages/automated_actions_client/automated_actions_client/models/validation_error.py
+++ b/packages/automated_actions_client/automated_actions_client/models/validation_error.py
@@ -1,5 +1,9 @@
 from collections.abc import Mapping
-from typing import Any, TypeVar, cast
+from typing import (
+    Any,
+    TypeVar,
+    cast,
+)
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field

--- a/packages/automated_actions_client/openapi_python_client_templates/endpoint_module.py.jinja
+++ b/packages/automated_actions_client/openapi_python_client_templates/endpoint_module.py.jinja
@@ -51,15 +51,12 @@ def _get_kwargs(
 {% if endpoint.bodies | length > 1 %}
 {% for body in endpoint.bodies %}
     if isinstance(body, {{body.prop.get_type_string() }}):
-        {% set destination = "_" + body.body_type + "_body" %}
-        {{ body_to_kwarg(body, destination) | indent(8) }}
-        _kwargs["{{ body.body_type.value }}"] = {{ destination }}
+        {{ body_to_kwarg(body) | indent(8) }}
         headers["Content-Type"] = "{{ body.content_type }}"
 {% endfor %}
 {% elif endpoint.bodies | length == 1 %}
 {% set body = endpoint.bodies[0] %}
-    {{ body_to_kwarg(body, "_body") | indent(4) }}
-    _kwargs["{{ body.body_type.value }}"] = _body
+    {{ body_to_kwarg(body) | indent(4) }}
     {% if body.content_type != "multipart/form-data" %}{# Need httpx to set the boundary automatically #}
     headers["Content-Type"] = "{{ body.content_type }}"
     {% endif %}
@@ -70,27 +67,31 @@ def _get_kwargs(
 {% endif %}
     return _kwargs
 
+{% if endpoint.responses.default %}
+    {% set return_type = return_string %}
+{% else %}
+    {% set return_type = "Optional[" + return_string + "]" %}
+{% endif %}
 
-def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[{{ return_string }}]:
-    {% for response in endpoint.responses %}
-    if response.status_code == {{ response.status_code.value }}:
-        {% if parsed_responses %}{% import "property_templates/" + response.prop.template as prop_template %}
-        {% if prop_template.construct %}
-        {{ prop_template.construct(response.prop, response.source.attribute) | indent(8) }}
-        {% elif response.source.return_type == response.prop.get_type_string()  %}
-        {{ response.prop.python_name }} = {{ response.source.attribute }}
-        {% else %}
-        {{ response.prop.python_name }} = cast({{ response.prop.get_type_string() }}, {{ response.source.attribute }})
-        {% endif %}
-        return {{ response.prop.python_name }}
-        {% else %}
-        return None
-        {% endif %}
+
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> {{return_type}}:
+    {% for response in endpoint.responses.patterns %}
+    {% set code_range = response.status_code.range %}
+    {% if code_range[0] == code_range[1] %}
+    if response.status_code == {{ code_range[0] }}:
+    {% else %}
+    if {{ code_range[0] }} <= response.status_code <= {{ code_range[1] }}:
+    {% endif %}
+        {{ parse_response(parsed_responses, response) | indent(8) }}
     {% endfor %}
+    {% if endpoint.responses.default %}
+    {{ parse_response(parsed_responses, endpoint.responses.default) | indent(4) }}
+    {% else %}
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:
         return None
+    {% endif %}
 
 
 def _build_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Response[{{ return_string }}]:
@@ -111,10 +112,9 @@ def sync_detailed(
         {{ kwargs(endpoint, include_client=False) }}
     )
 
-    with client as _client:
-        response = _client.request(
-            **kwargs,
-        )
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
 
     return _build_response(client=client, response=response)
 
@@ -138,10 +138,9 @@ async def asyncio_detailed(
         {{ kwargs(endpoint, include_client=False) }}
     )
 
-    async with client as _client:
-        response = await _client.request(
-            **kwargs,
-        )
+    response = await client.get_async_httpx_client().request(
+        **kwargs
+    )
 
     return _build_response(client=client, response=response)
 

--- a/packages/automated_actions_client/openapi_python_client_templates/types.py.jinja
+++ b/packages/automated_actions_client/openapi_python_client_templates/types.py.jinja
@@ -3,7 +3,7 @@
 
 from collections.abc import Mapping, MutableMapping
 from http import HTTPStatus
-from typing import IO, BinaryIO, Generic, Literal, TypeVar
+from typing import BinaryIO, Generic, Optional, TypeVar, Literal, Union, IO
 
 from attrs import define
 
@@ -19,23 +19,19 @@ UNSET: Unset = Unset()
 FileContent = IO[bytes] | bytes | str
 # (filename, file (or bytes), content_type)
 # (filename, file (or bytes), content_type, headers)
-FileTypes = (
-    tuple[str | None, FileContent, str | None]
-    | tuple[str | None, FileContent, str | None, Mapping[str, str]]
-)
+FileTypes = tuple[Optional[str], FileContent, Optional[str]] | tuple[Optional[str], FileContent, Optional[str], Mapping[str, str]]
 RequestFiles = list[tuple[str, FileTypes]]
-
 
 @define
 class File:
-    """Contains information for file uploads"""
+    """ Contains information for file uploads """
 
     payload: BinaryIO
-    file_name: str | None = None
-    mime_type: str | None = None
+    file_name: Optional[str] = None
+    mime_type: Optional[str] = None
 
     def to_tuple(self) -> FileTypes:
-        """Return a tuple representation that httpx will accept for multipart/form-data"""
+        """ Return a tuple representation that httpx will accept for multipart/form-data """
         return self.file_name, self.payload, self.mime_type
 
 
@@ -44,12 +40,12 @@ T = TypeVar("T")
 
 @define
 class Response(Generic[T]):
-    """A response from an endpoint"""
+    """ A response from an endpoint """
 
     status_code: HTTPStatus
     content: bytes
     headers: MutableMapping[str, str]
-    parsed: T | None
+    parsed: Optional[T]
 
 
 __all__ = ["UNSET", "File", "FileTypes", "RequestFiles", "Response", "Unset"]

--- a/packages/automated_actions_client/pyproject.toml
+++ b/packages/automated_actions_client/pyproject.toml
@@ -21,7 +21,8 @@ documentation = "https://github.com/app-sre/automated-actions"
 dev = [
     # Development dependencies
     "mypy==1.18.2",
-    # disabled until https://github.com/openapi-generators/openapi-python-client/pull/1324 is available in 0.26.2
+    # we don't install this directly anymore, because it may have an outdated typer version dependency and this breaks Renovate
+    # instead, we use a specific version in the compose.yml file
     # "openapi-python-client==0.25.3",
     "pytest-cov==6.3.0",
     "pytest==8.4.2",


### PR DESCRIPTION
This PR upgrades the openapi-python-client dependency from version 0.25.3 to 0.26.2. The upgrade modifies how the client is installed and used, moving from a direct dependency to using a specific version in the compose.yml file to avoid conflicts with outdated typer dependencies that can break Renovate.