### PR TITLE
fix: switch DynamoDB tables to on-demand billing

### DIFF
--- a/packages/automated_actions/automated_actions/api/__init__.py
+++ b/packages/automated_actions/automated_actions/api/__init__.py
@@ -17,9 +17,7 @@ def create_db_tables() -> None:
     for table_model in ALL_TABLES:
         if not table_model.exists():
             log.info(f"Creating table {table_model.Meta.table_name}...")
-            table_model.create_table(
-                read_capacity_units=1, write_capacity_units=1, wait=True
-            )
+            table_model.create_table(wait=True)
             log.info(f"Table {table_model.Meta.table_name} created.")
     log.info("All tables checked.")
 

--- a/packages/automated_actions/automated_actions/db/models/_action.py
+++ b/packages/automated_actions/automated_actions/db/models/_action.py
@@ -57,8 +57,6 @@ class ActionSchemaOut(ActionSchemaIn):
 class OwnerIndex(GlobalSecondaryIndex["Action"]):
     class Meta:
         index_name = "owner-index"
-        read_capacity_units = 10
-        write_capacity_units = 10
         projection = AllProjection()
 
     owner = UnicodeAttribute(hash_key=True)

--- a/packages/automated_actions/automated_actions/db/models/_base.py
+++ b/packages/automated_actions/automated_actions/db/models/_base.py
@@ -26,6 +26,7 @@ class Table[SchemaIn: PydanticBaseModel, SchemaOut: PydanticBaseModel](PynamoMod
         region = settings.dynamodb_aws_region
         aws_access_key_id = settings.dynamodb_aws_access_key_id
         aws_secret_access_key = settings.dynamodb_aws_secret_access_key
+        billing_mode = "PAY_PER_REQUEST"
         tags: ClassVar = {"app": "automated-actions"}
         schema_out: Any
 


### PR DESCRIPTION
## Summary

- Switches all DynamoDB tables from provisioned capacity to on-demand billing (`PAY_PER_REQUEST`)
- Fixes `ProvisionedThroughputExceededException` when running `action-list --status FAILURE`
- Root cause: the `owner-index` GSI had only 10 RCU provisioned, and status filtering via `filter_condition` consumes RCU for every item read (not just returned items), easily exceeding the limit

## Changes

- Add `billing_mode = 'PAY_PER_REQUEST'` to base `Table.Meta` (applies to all tables)
- Remove `read_capacity_units`/`write_capacity_units` from `OwnerIndex` GSI (ignored with on-demand)
- Remove provisioned capacity params from `create_table()` call

## Post-deploy action required

Existing production tables need a one-time manual migration:

```bash
aws dynamodb update-table --table-name aa-production-actions --billing-mode PAY_PER_REQUEST
aws dynamodb update-table --table-name aa-production-user --billing-mode PAY_PER_REQUEST
```

## Test plan

- [x] `make format` passes
- [x] `make test` passes (all 26 tests)
- [ ] Verify locally via `docker compose up` that tables are created with on-demand billing
- [ ] Run AWS CLI commands on production after deploy