### PR TITLE
feat: RDS start/stop wait for actual instance state (APPSRE-14721)

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -157,6 +157,20 @@ Follow the checklist in `docs/development-guides/implementing-new-actions.md`:
 5. Regenerate client with `make generate-client`
 6. Update documentation in `actions.md`
 
+### Long-Running Celery Tasks (Retry-Based Polling)
+
+For actions that wait on an external state change (e.g., RDS instance reaching "available" or "stopped"), **never use `time.sleep()` in a loop**. It blocks the worker and is not resilient to worker restarts.
+
+Instead, use Celery's `self.retry(countdown=N)` pattern:
+
+- **`bind=True`** on the task to access `self.retry()`
+- **`max_retries=60`** (or appropriate value) to allow enough polling attempts
+- **Task must be idempotent**: check the current state before triggering the operation. On each retry, the task re-executes from scratch — it must not re-send an API call that's already in progress.
+- **`run()` returns `bool`**: `True` = target state reached (task succeeds), `False` = retry needed
+- **Terminal error detection**: check for error states and raise `RuntimeError` to fail fast instead of polling until timeout
+
+See `ExternalResourceRDSStart` / `ExternalResourceRDSStop` in `automated_actions/celery/external_resource/tasks.py` for the reference implementation.
+
 ### Testing Strategy
 
 - Unit tests for individual components

--- a/docs/development-guides/implementing-new-actions.md
+++ b/docs/development-guides/implementing-new-actions.md
@@ -44,6 +44,42 @@ For actions that require asynchronous processing, implement a Celery task:
 
 A good example of a Celery task can be found in the [no-op](/packages/automated_actions/automated_actions/celery/external_resource/tasks.py) action.
 
+### Long-Running Tasks (Waiting for External State)
+
+If your action needs to wait for an external system to reach a target state (e.g., an RDS instance becoming `available` after a start), **do not use `time.sleep()` in a loop**. A sleep-loop blocks the Celery worker for the entire duration and is not resilient to worker restarts — if the worker is killed (OOM, deployment), the action gets stuck in `RUNNING` forever.
+
+Instead, use Celery's **retry-based polling** pattern:
+
+1. Use `bind=True` and a high `max_retries` on the task decorator:
+   ```python
+   @app.task(bind=True, base=AutomatedActionTask, max_retries=60)
+   def my_task(self: Task, ..., *, action: Action) -> None:
+   ```
+
+2. Make the task **idempotent** — on each execution, check the current state before triggering the operation:
+   ```python
+   class MyAction:
+       def run(self) -> bool:
+           status = self.api.get_status(self.identifier)
+           if status == "target_state":
+               return True    # Done — task succeeds
+           if status in ERROR_STATES:
+               raise RuntimeError(f"Terminal error: {status}")  # Fail fast
+           if status == "source_state":
+               self.api.trigger_operation(self.identifier)  # Only trigger if not already in progress
+           return False       # Not done — retry needed
+   ```
+
+3. In the task function, retry when the target state is not yet reached:
+   ```python
+   if not MyAction(api, resource).run():
+       raise self.retry(countdown=30)
+   ```
+
+Each retry is a separate task execution — the worker is free between polls, and pending retries survive worker restarts via the SQS message broker.
+
+See `ExternalResourceRDSStart` / `ExternalResourceRDSStop` in [`tasks.py`](/packages/automated_actions/automated_actions/celery/external_resource/tasks.py) for the reference implementation.
+
 ### Write Tests
 
 Testing is crucial to ensure your new action works as expected. You need to implement both unit tests for the action logic and integration tests for the FastAPI endpoint.

--- a/packages/automated_actions/automated_actions/celery/external_resource/tasks.py
+++ b/packages/automated_actions/automated_actions/celery/external_resource/tasks.py
@@ -1,6 +1,10 @@
 from typing import TYPE_CHECKING
 
-from automated_actions_utils.aws_api import AWSApi, get_aws_credentials
+from automated_actions_utils.aws_api import (
+    RDS_TERMINAL_ERROR_STATES,
+    AWSApi,
+    get_aws_credentials,
+)
 from automated_actions_utils.cluster_connection import get_cluster_connection_data
 from automated_actions_utils.external_resource import (
     ExternalResource,
@@ -19,6 +23,9 @@ from automated_actions.config import settings
 
 if TYPE_CHECKING:
     from automated_actions.db.models import Action
+    from celery import Task
+
+RDS_STATUS_POLL_COUNTDOWN = 30
 
 
 class ExternalResourceRDSReboot:
@@ -91,16 +98,28 @@ def external_resource_rds_snapshot(
 
 
 class ExternalResourceRDSStart:
+    """Idempotent RDS start — safe to retry on worker restart."""
+
     def __init__(self, aws_api: AWSApi, rds: ExternalResource) -> None:
         self.aws_api = aws_api
         self.rds = rds
 
-    def run(self) -> None:
-        self.aws_api.start_rds_instance(identifier=self.rds.identifier)
+    def run(self) -> bool:
+        """Returns True if the instance is available, False if a retry is needed."""
+        status = self.aws_api.get_rds_instance_status(self.rds.identifier)
+        if status == "available":
+            return True
+        if status in RDS_TERMINAL_ERROR_STATES:
+            msg = f"RDS instance {self.rds.identifier} entered terminal error state '{status}'"
+            raise RuntimeError(msg)
+        if status == "stopped":
+            self.aws_api.start_rds_instance(identifier=self.rds.identifier)
+        return False
 
 
-@app.task(base=AutomatedActionTask)
+@app.task(bind=True, base=AutomatedActionTask, max_retries=60)
 def external_resource_rds_start(
+    self: Task,
     account: str,
     identifier: str,
     *,
@@ -116,20 +135,33 @@ def external_resource_rds_start(
         vault_secret=rds.account.automation_token, region=rds.account.region
     )
     with AWSApi(credentials=credentials, region=rds.region) as aws_api:
-        ExternalResourceRDSStart(aws_api, rds).run()
+        if not ExternalResourceRDSStart(aws_api, rds).run():
+            raise self.retry(countdown=RDS_STATUS_POLL_COUNTDOWN)
 
 
 class ExternalResourceRDSStop:
+    """Idempotent RDS stop — safe to retry on worker restart."""
+
     def __init__(self, aws_api: AWSApi, rds: ExternalResource) -> None:
         self.aws_api = aws_api
         self.rds = rds
 
-    def run(self) -> None:
-        self.aws_api.stop_rds_instance(identifier=self.rds.identifier)
+    def run(self) -> bool:
+        """Returns True if the instance is stopped, False if a retry is needed."""
+        status = self.aws_api.get_rds_instance_status(self.rds.identifier)
+        if status == "stopped":
+            return True
+        if status in RDS_TERMINAL_ERROR_STATES:
+            msg = f"RDS instance {self.rds.identifier} entered terminal error state '{status}'"
+            raise RuntimeError(msg)
+        if status == "available":
+            self.aws_api.stop_rds_instance(identifier=self.rds.identifier)
+        return False
 
 
-@app.task(base=AutomatedActionTask)
+@app.task(bind=True, base=AutomatedActionTask, max_retries=60)
 def external_resource_rds_stop(
+    self: Task,
     account: str,
     identifier: str,
     *,
@@ -145,7 +177,8 @@ def external_resource_rds_stop(
         vault_secret=rds.account.automation_token, region=rds.account.region
     )
     with AWSApi(credentials=credentials, region=rds.region) as aws_api:
-        ExternalResourceRDSStop(aws_api, rds).run()
+        if not ExternalResourceRDSStop(aws_api, rds).run():
+            raise self.retry(countdown=RDS_STATUS_POLL_COUNTDOWN)
 
 
 class ExternalResourceFlushElastiCache:

--- a/packages/automated_actions/automated_actions/celery/external_resource/tasks.py
+++ b/packages/automated_actions/automated_actions/celery/external_resource/tasks.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING
 from automated_actions_utils.aws_api import (
     RDS_TERMINAL_ERROR_STATES,
     AWSApi,
+    RdsInstanceStatus,
     get_aws_credentials,
 )
 from automated_actions_utils.cluster_connection import get_cluster_connection_data
@@ -107,12 +108,12 @@ class ExternalResourceRDSStart:
     def run(self) -> bool:
         """Returns True if the instance is available, False if a retry is needed."""
         status = self.aws_api.get_rds_instance_status(self.rds.identifier)
-        if status == "available":
+        if status == RdsInstanceStatus.AVAILABLE:
             return True
         if status in RDS_TERMINAL_ERROR_STATES:
             msg = f"RDS instance {self.rds.identifier} entered terminal error state '{status}'"
             raise RuntimeError(msg)
-        if status == "stopped":
+        if status == RdsInstanceStatus.STOPPED:
             self.aws_api.start_rds_instance(identifier=self.rds.identifier)
         return False
 
@@ -149,12 +150,12 @@ class ExternalResourceRDSStop:
     def run(self) -> bool:
         """Returns True if the instance is stopped, False if a retry is needed."""
         status = self.aws_api.get_rds_instance_status(self.rds.identifier)
-        if status == "stopped":
+        if status == RdsInstanceStatus.STOPPED:
             return True
         if status in RDS_TERMINAL_ERROR_STATES:
             msg = f"RDS instance {self.rds.identifier} entered terminal error state '{status}'"
             raise RuntimeError(msg)
-        if status == "available":
+        if status == RdsInstanceStatus.AVAILABLE:
             self.aws_api.stop_rds_instance(identifier=self.rds.identifier)
         return False
 

--- a/packages/automated_actions/tests/celery/test_external_resource.py
+++ b/packages/automated_actions/tests/celery/test_external_resource.py
@@ -140,12 +140,44 @@ def test_external_resource_rds_reboot_task_non_retryable_failure(
     )
 
 
-def test_external_resource_rds_start_run(mock_aws: Mock, er: ExternalResource) -> None:
+def test_external_resource_rds_start_run_already_available(
+    mock_aws: Mock, er: ExternalResource
+) -> None:
+    mock_aws.get_rds_instance_status.return_value = "available"
     automated_action = ExternalResourceRDSStart(aws_api=mock_aws, rds=er)
 
-    automated_action.run()
+    assert automated_action.run() is True
+    mock_aws.start_rds_instance.assert_not_called()
 
+
+def test_external_resource_rds_start_run_from_stopped(
+    mock_aws: Mock, er: ExternalResource
+) -> None:
+    mock_aws.get_rds_instance_status.return_value = "stopped"
+    automated_action = ExternalResourceRDSStart(aws_api=mock_aws, rds=er)
+
+    assert automated_action.run() is False
     mock_aws.start_rds_instance.assert_called_once_with(identifier=er.identifier)
+
+
+def test_external_resource_rds_start_run_starting(
+    mock_aws: Mock, er: ExternalResource
+) -> None:
+    mock_aws.get_rds_instance_status.return_value = "starting"
+    automated_action = ExternalResourceRDSStart(aws_api=mock_aws, rds=er)
+
+    assert automated_action.run() is False
+    mock_aws.start_rds_instance.assert_not_called()
+
+
+def test_external_resource_rds_start_run_terminal_error(
+    mock_aws: Mock, er: ExternalResource
+) -> None:
+    mock_aws.get_rds_instance_status.return_value = "failed"
+    automated_action = ExternalResourceRDSStart(aws_api=mock_aws, rds=er)
+
+    with pytest.raises(RuntimeError, match="terminal error state 'failed'"):
+        automated_action.run()
 
 
 def test_external_resource_rds_start_task(
@@ -163,7 +195,7 @@ def test_external_resource_rds_start_task(
             region="us-west-2",
         ),
     )
-    mock_rds_start_run = mocker.patch.object(ExternalResourceRDSStart, "run")
+    mocker.patch.object(ExternalResourceRDSStart, "run", return_value=True)
 
     action_id = str(uuid.uuid4())
     task_args = {
@@ -175,7 +207,6 @@ def test_external_resource_rds_start_task(
         task_id=action_id,
     ).apply()
 
-    mock_rds_start_run.assert_called_once()
     mock_action.set_status.assert_called_once_with(ActionStatus.RUNNING)
     mock_action.set_final_state.assert_called_once_with(
         status=ActionStatus.SUCCESS, result="ok", task_args=task_args
@@ -197,7 +228,7 @@ def test_external_resource_rds_start_task_non_retryable_failure(
             region="us-west-2",
         ),
     )
-    mock_rds_start_run = mocker.patch.object(
+    mocker.patch.object(
         ExternalResourceRDSStart,
         "run",
         side_effect=Exception("what a failure!"),
@@ -213,7 +244,6 @@ def test_external_resource_rds_start_task_non_retryable_failure(
         task_id=action_id,
     ).apply()
 
-    mock_rds_start_run.assert_called_once()
     mock_action.set_status.assert_called_once_with(ActionStatus.RUNNING)
     mock_action.set_final_state.assert_called_once_with(
         status=ActionStatus.FAILURE,
@@ -222,12 +252,44 @@ def test_external_resource_rds_start_task_non_retryable_failure(
     )
 
 
-def test_external_resource_rds_stop_run(mock_aws: Mock, er: ExternalResource) -> None:
+def test_external_resource_rds_stop_run_already_stopped(
+    mock_aws: Mock, er: ExternalResource
+) -> None:
+    mock_aws.get_rds_instance_status.return_value = "stopped"
     automated_action = ExternalResourceRDSStop(aws_api=mock_aws, rds=er)
 
-    automated_action.run()
+    assert automated_action.run() is True
+    mock_aws.stop_rds_instance.assert_not_called()
 
+
+def test_external_resource_rds_stop_run_from_available(
+    mock_aws: Mock, er: ExternalResource
+) -> None:
+    mock_aws.get_rds_instance_status.return_value = "available"
+    automated_action = ExternalResourceRDSStop(aws_api=mock_aws, rds=er)
+
+    assert automated_action.run() is False
     mock_aws.stop_rds_instance.assert_called_once_with(identifier=er.identifier)
+
+
+def test_external_resource_rds_stop_run_stopping(
+    mock_aws: Mock, er: ExternalResource
+) -> None:
+    mock_aws.get_rds_instance_status.return_value = "stopping"
+    automated_action = ExternalResourceRDSStop(aws_api=mock_aws, rds=er)
+
+    assert automated_action.run() is False
+    mock_aws.stop_rds_instance.assert_not_called()
+
+
+def test_external_resource_rds_stop_run_terminal_error(
+    mock_aws: Mock, er: ExternalResource
+) -> None:
+    mock_aws.get_rds_instance_status.return_value = "failed"
+    automated_action = ExternalResourceRDSStop(aws_api=mock_aws, rds=er)
+
+    with pytest.raises(RuntimeError, match="terminal error state 'failed'"):
+        automated_action.run()
 
 
 def test_external_resource_rds_stop_task(
@@ -245,7 +307,7 @@ def test_external_resource_rds_stop_task(
             region="us-west-2",
         ),
     )
-    mock_rds_stop_run = mocker.patch.object(ExternalResourceRDSStop, "run")
+    mocker.patch.object(ExternalResourceRDSStop, "run", return_value=True)
 
     action_id = str(uuid.uuid4())
     task_args = {
@@ -257,7 +319,6 @@ def test_external_resource_rds_stop_task(
         task_id=action_id,
     ).apply()
 
-    mock_rds_stop_run.assert_called_once()
     mock_action.set_status.assert_called_once_with(ActionStatus.RUNNING)
     mock_action.set_final_state.assert_called_once_with(
         status=ActionStatus.SUCCESS, result="ok", task_args=task_args
@@ -279,7 +340,7 @@ def test_external_resource_rds_stop_task_non_retryable_failure(
             region="us-west-2",
         ),
     )
-    mock_rds_stop_run = mocker.patch.object(
+    mocker.patch.object(
         ExternalResourceRDSStop,
         "run",
         side_effect=Exception("what a failure!"),
@@ -295,7 +356,6 @@ def test_external_resource_rds_stop_task_non_retryable_failure(
         task_id=action_id,
     ).apply()
 
-    mock_rds_stop_run.assert_called_once()
     mock_action.set_status.assert_called_once_with(ActionStatus.RUNNING)
     mock_action.set_final_state.assert_called_once_with(
         status=ActionStatus.FAILURE,

--- a/packages/automated_actions/tests/celery/test_external_resource.py
+++ b/packages/automated_actions/tests/celery/test_external_resource.py
@@ -3,7 +3,11 @@ from typing import TYPE_CHECKING
 from unittest.mock import ANY, Mock
 
 import pytest
-from automated_actions_utils.aws_api import AWSApi, AWSStaticCredentials
+from automated_actions_utils.aws_api import (
+    AWSApi,
+    AWSStaticCredentials,
+    RdsInstanceStatus,
+)
 from automated_actions_utils.cluster_connection import ClusterConnectionData
 from automated_actions_utils.external_resource import (
     AwsAccount,
@@ -143,7 +147,7 @@ def test_external_resource_rds_reboot_task_non_retryable_failure(
 def test_external_resource_rds_start_run_already_available(
     mock_aws: Mock, er: ExternalResource
 ) -> None:
-    mock_aws.get_rds_instance_status.return_value = "available"
+    mock_aws.get_rds_instance_status.return_value = RdsInstanceStatus.AVAILABLE
     automated_action = ExternalResourceRDSStart(aws_api=mock_aws, rds=er)
 
     assert automated_action.run() is True
@@ -153,7 +157,7 @@ def test_external_resource_rds_start_run_already_available(
 def test_external_resource_rds_start_run_from_stopped(
     mock_aws: Mock, er: ExternalResource
 ) -> None:
-    mock_aws.get_rds_instance_status.return_value = "stopped"
+    mock_aws.get_rds_instance_status.return_value = RdsInstanceStatus.STOPPED
     automated_action = ExternalResourceRDSStart(aws_api=mock_aws, rds=er)
 
     assert automated_action.run() is False
@@ -163,7 +167,7 @@ def test_external_resource_rds_start_run_from_stopped(
 def test_external_resource_rds_start_run_starting(
     mock_aws: Mock, er: ExternalResource
 ) -> None:
-    mock_aws.get_rds_instance_status.return_value = "starting"
+    mock_aws.get_rds_instance_status.return_value = RdsInstanceStatus.STARTING
     automated_action = ExternalResourceRDSStart(aws_api=mock_aws, rds=er)
 
     assert automated_action.run() is False
@@ -173,7 +177,7 @@ def test_external_resource_rds_start_run_starting(
 def test_external_resource_rds_start_run_terminal_error(
     mock_aws: Mock, er: ExternalResource
 ) -> None:
-    mock_aws.get_rds_instance_status.return_value = "failed"
+    mock_aws.get_rds_instance_status.return_value = RdsInstanceStatus.FAILED
     automated_action = ExternalResourceRDSStart(aws_api=mock_aws, rds=er)
 
     with pytest.raises(RuntimeError, match="terminal error state 'failed'"):
@@ -255,7 +259,7 @@ def test_external_resource_rds_start_task_non_retryable_failure(
 def test_external_resource_rds_stop_run_already_stopped(
     mock_aws: Mock, er: ExternalResource
 ) -> None:
-    mock_aws.get_rds_instance_status.return_value = "stopped"
+    mock_aws.get_rds_instance_status.return_value = RdsInstanceStatus.STOPPED
     automated_action = ExternalResourceRDSStop(aws_api=mock_aws, rds=er)
 
     assert automated_action.run() is True
@@ -265,7 +269,7 @@ def test_external_resource_rds_stop_run_already_stopped(
 def test_external_resource_rds_stop_run_from_available(
     mock_aws: Mock, er: ExternalResource
 ) -> None:
-    mock_aws.get_rds_instance_status.return_value = "available"
+    mock_aws.get_rds_instance_status.return_value = RdsInstanceStatus.AVAILABLE
     automated_action = ExternalResourceRDSStop(aws_api=mock_aws, rds=er)
 
     assert automated_action.run() is False
@@ -275,7 +279,7 @@ def test_external_resource_rds_stop_run_from_available(
 def test_external_resource_rds_stop_run_stopping(
     mock_aws: Mock, er: ExternalResource
 ) -> None:
-    mock_aws.get_rds_instance_status.return_value = "stopping"
+    mock_aws.get_rds_instance_status.return_value = RdsInstanceStatus.STOPPING
     automated_action = ExternalResourceRDSStop(aws_api=mock_aws, rds=er)
 
     assert automated_action.run() is False
@@ -285,7 +289,7 @@ def test_external_resource_rds_stop_run_stopping(
 def test_external_resource_rds_stop_run_terminal_error(
     mock_aws: Mock, er: ExternalResource
 ) -> None:
-    mock_aws.get_rds_instance_status.return_value = "failed"
+    mock_aws.get_rds_instance_status.return_value = RdsInstanceStatus.FAILED
     automated_action = ExternalResourceRDSStop(aws_api=mock_aws, rds=er)
 
     with pytest.raises(RuntimeError, match="terminal error state 'failed'"):

--- a/packages/automated_actions_utils/automated_actions_utils/aws_api.py
+++ b/packages/automated_actions_utils/automated_actions_utils/aws_api.py
@@ -1,6 +1,6 @@
 import logging
 from abc import ABC, abstractmethod
-from typing import Any, Protocol, Self
+from typing import Any, Literal, Protocol, Self
 
 from automated_actions.config import settings
 from boto3 import Session
@@ -12,6 +12,20 @@ from types_boto3_rds.type_defs import EventTypeDef
 from automated_actions_utils.vault_client import SecretFieldNotFoundError, VaultClient
 
 log = logging.getLogger(__name__)
+
+RDS_TERMINAL_ERROR_STATES = frozenset({
+    "failed",
+    "incompatible-network",
+    "incompatible-option-group",
+    "incompatible-parameters",
+    "incompatible-restore",
+    "inaccessible-encryption-credentials",
+    "inaccessible-encryption-credentials-recoverable",
+    "restore-error",
+    "storage-full",
+})
+
+type RdsTargetStatus = Literal["available", "stopped"]
 
 
 class VaultSecret(Protocol):
@@ -132,6 +146,20 @@ class AWSApi:
         """
         log.info(f"Stopping RDS instance {identifier}")
         self.rds_client.stop_db_instance(DBInstanceIdentifier=identifier)
+
+    def get_rds_instance_status(self, identifier: str) -> str:
+        """Returns the current status of an RDS instance.
+
+        Args:
+            identifier: The DB instance identifier.
+
+        Returns:
+            The DBInstanceStatus string (e.g. "available", "stopped", "stopping", "starting").
+        """
+        response = self.rds_client.describe_db_instances(
+            DBInstanceIdentifier=identifier
+        )
+        return response["DBInstances"][0]["DBInstanceStatus"]
 
     def rds_get_events(
         self,

--- a/packages/automated_actions_utils/automated_actions_utils/aws_api.py
+++ b/packages/automated_actions_utils/automated_actions_utils/aws_api.py
@@ -1,6 +1,7 @@
 import logging
 from abc import ABC, abstractmethod
-from typing import Any, Literal, Protocol, Self
+from enum import StrEnum
+from typing import Any, Protocol, Self
 
 from automated_actions.config import settings
 from boto3 import Session
@@ -13,19 +14,46 @@ from automated_actions_utils.vault_client import SecretFieldNotFoundError, Vault
 
 log = logging.getLogger(__name__)
 
-RDS_TERMINAL_ERROR_STATES = frozenset({
-    "failed",
-    "incompatible-network",
-    "incompatible-option-group",
-    "incompatible-parameters",
-    "incompatible-restore",
-    "inaccessible-encryption-credentials",
-    "inaccessible-encryption-credentials-recoverable",
-    "restore-error",
-    "storage-full",
-})
 
-type RdsTargetStatus = Literal["available", "stopped"]
+class RdsInstanceStatus(StrEnum):
+    """Known RDS DB instance statuses."""
+
+    AVAILABLE = "available"
+    BACKING_UP = "backing-up"
+    CREATING = "creating"
+    DELETING = "deleting"
+    FAILED = "failed"
+    INACCESSIBLE_ENCRYPTION_CREDENTIALS = "inaccessible-encryption-credentials"
+    INACCESSIBLE_ENCRYPTION_CREDENTIALS_RECOVERABLE = (
+        "inaccessible-encryption-credentials-recoverable"
+    )
+    INCOMPATIBLE_NETWORK = "incompatible-network"
+    INCOMPATIBLE_OPTION_GROUP = "incompatible-option-group"
+    INCOMPATIBLE_PARAMETERS = "incompatible-parameters"
+    INCOMPATIBLE_RESTORE = "incompatible-restore"
+    MAINTENANCE = "maintenance"
+    MODIFYING = "modifying"
+    REBOOTING = "rebooting"
+    RESTORE_ERROR = "restore-error"
+    STARTING = "starting"
+    STOPPED = "stopped"
+    STOPPING = "stopping"
+    STORAGE_FULL = "storage-full"
+    STORAGE_OPTIMIZATION = "storage-optimization"
+    UPGRADING = "upgrading"
+
+
+RDS_TERMINAL_ERROR_STATES = frozenset({
+    RdsInstanceStatus.FAILED,
+    RdsInstanceStatus.INCOMPATIBLE_NETWORK,
+    RdsInstanceStatus.INCOMPATIBLE_OPTION_GROUP,
+    RdsInstanceStatus.INCOMPATIBLE_PARAMETERS,
+    RdsInstanceStatus.INCOMPATIBLE_RESTORE,
+    RdsInstanceStatus.INACCESSIBLE_ENCRYPTION_CREDENTIALS,
+    RdsInstanceStatus.INACCESSIBLE_ENCRYPTION_CREDENTIALS_RECOVERABLE,
+    RdsInstanceStatus.RESTORE_ERROR,
+    RdsInstanceStatus.STORAGE_FULL,
+})
 
 
 class VaultSecret(Protocol):
@@ -147,19 +175,19 @@ class AWSApi:
         log.info(f"Stopping RDS instance {identifier}")
         self.rds_client.stop_db_instance(DBInstanceIdentifier=identifier)
 
-    def get_rds_instance_status(self, identifier: str) -> str:
+    def get_rds_instance_status(self, identifier: str) -> RdsInstanceStatus:
         """Returns the current status of an RDS instance.
 
         Args:
             identifier: The DB instance identifier.
 
         Returns:
-            The DBInstanceStatus string (e.g. "available", "stopped", "stopping", "starting").
+            The RdsInstanceStatus enum value.
         """
         response = self.rds_client.describe_db_instances(
             DBInstanceIdentifier=identifier
         )
-        return response["DBInstances"][0]["DBInstanceStatus"]
+        return RdsInstanceStatus(response["DBInstances"][0]["DBInstanceStatus"])
 
     def rds_get_events(
         self,

--- a/packages/automated_actions_utils/tests/test_aws_api.py
+++ b/packages/automated_actions_utils/tests/test_aws_api.py
@@ -9,6 +9,7 @@ from pytest_mock import MockerFixture
 from automated_actions_utils.aws_api import (
     AWSApi,
     AWSStaticCredentials,
+    RdsInstanceStatus,
     get_aws_credentials,
 )
 from automated_actions_utils.vault_client import SecretFieldNotFoundError
@@ -392,9 +393,9 @@ def test_aws_api_rds_get_events(
 @pytest.mark.parametrize(
     ("region", "identifier", "expected_status"),
     [
-        ("us-east-1", "test-db-instance", "available"),
-        ("eu-west-1", "stopped-db", "stopped"),
-        ("ap-south-1", "starting-db", "starting"),
+        ("us-east-1", "test-db-instance", RdsInstanceStatus.AVAILABLE),
+        ("eu-west-1", "stopped-db", RdsInstanceStatus.STOPPED),
+        ("ap-south-1", "starting-db", RdsInstanceStatus.STARTING),
     ],
     ids=["available", "stopped", "starting"],
 )
@@ -403,19 +404,20 @@ def test_aws_api_get_rds_instance_status(
     mocker: MockerFixture,
     region: str,
     identifier: str,
-    expected_status: str,
+    expected_status: RdsInstanceStatus,
 ) -> None:
     aws_api = AWSApi(credentials=mock_aws_credentials, region=region)
 
     mock_rds_client = mocker.MagicMock()
     aws_api.rds_client = mock_rds_client
     mock_rds_client.describe_db_instances.return_value = {
-        "DBInstances": [{"DBInstanceStatus": expected_status}]
+        "DBInstances": [{"DBInstanceStatus": expected_status.value}]
     }
 
     status = aws_api.get_rds_instance_status(identifier=identifier)
 
     assert status == expected_status
+    assert isinstance(status, RdsInstanceStatus)
     mock_rds_client.describe_db_instances.assert_called_once_with(
         DBInstanceIdentifier=identifier
     )

--- a/packages/automated_actions_utils/tests/test_aws_api.py
+++ b/packages/automated_actions_utils/tests/test_aws_api.py
@@ -390,6 +390,38 @@ def test_aws_api_rds_get_events(
 
 
 @pytest.mark.parametrize(
+    ("region", "identifier", "expected_status"),
+    [
+        ("us-east-1", "test-db-instance", "available"),
+        ("eu-west-1", "stopped-db", "stopped"),
+        ("ap-south-1", "starting-db", "starting"),
+    ],
+    ids=["available", "stopped", "starting"],
+)
+def test_aws_api_get_rds_instance_status(
+    mock_aws_credentials: MagicMock,
+    mocker: MockerFixture,
+    region: str,
+    identifier: str,
+    expected_status: str,
+) -> None:
+    aws_api = AWSApi(credentials=mock_aws_credentials, region=region)
+
+    mock_rds_client = mocker.MagicMock()
+    aws_api.rds_client = mock_rds_client
+    mock_rds_client.describe_db_instances.return_value = {
+        "DBInstances": [{"DBInstanceStatus": expected_status}]
+    }
+
+    status = aws_api.get_rds_instance_status(identifier=identifier)
+
+    assert status == expected_status
+    mock_rds_client.describe_db_instances.assert_called_once_with(
+        DBInstanceIdentifier=identifier
+    )
+
+
+@pytest.mark.parametrize(
     ("region", "identifier", "snapshot_identifier"),
     [
         ("eu-central-1", "test-db-instance", "test-snapshot-identifier"),


### PR DESCRIPTION
## Summary

- RDS start/stop actions now wait for the actual instance state (`available`/`stopped`) before marking the action as `SUCCESS`, instead of completing immediately after the API signal
- Uses Celery retry-based polling (`self.retry(countdown=30)`) instead of `time.sleep()` loops — workers stay free between polls and pending retries survive worker restarts via SQS
- Tasks are idempotent: each retry checks the current RDS status before deciding whether to call the API, avoiding duplicate start/stop calls
- Fails fast on terminal RDS error states (`failed`, `storage-full`, etc.) instead of polling for 30 minutes
- Documents the retry-based polling pattern in AGENT.md and implementing-new-actions.md

## Test plan

- [x] Unit tests for `get_rds_instance_status` (3 parametrized cases)
- [x] Unit tests for idempotent `run()` on both start and stop (4 cases each: already done, trigger, transitioning, terminal error)
- [x] Task-level tests for success and failure paths with `bind=True`
- [x] All 89 unit tests pass
- [x] mypy strict mode passes
- [x] ruff lint and format clean
- [x] OPA policy tests pass (26/26)