### PR TITLE
fix regal image

### DIFF
--- a/Dockerfile.opa
+++ b/Dockerfile.opa
@@ -13,7 +13,7 @@ COPY packages/opa/authz /authz
 # Test image
 #
 FROM base AS test
-COPY --from=ghcr.io/styrainc/regal:0.35.1@sha256:7caf9953f1c49054c94030ec7be087b46ae501fc347cdaace9557a57abd3f4ff /ko-app/regal /bin/regal
+COPY --from=ghcr.io/open-policy-agent/regal:0.42.0@sha256:07984036043f772a1f921bd0ad9045b8bd9dc58460a1d76f476c458dc8a98b16 /ko-app/regal /bin/regal
 
 USER 0
 RUN microdnf install -y make


### PR DESCRIPTION
`ghcr.io/styrainc/regal` doesn't exist anymore. let's switch to the new official one.