### PR TITLE
fix(opa): bind OPA sidecar to localhost, close unauthenticated policy API exposure

### DIFF
--- a/Dockerfile.opa
+++ b/Dockerfile.opa
@@ -1,3 +1,9 @@
+# ubi-minimal (not ubi-micro) is required here: OPA runs as a sidecar bound to
+# 127.0.0.1 only (see openshift/template.yaml), so kubelet's httpGet/tcpSocket
+# probes can't reach it from outside the pod netns. Liveness/readiness/startup
+# probes instead exec `curl` inside this container against 127.0.0.1:8181 —
+# provided by ubi-minimal's curl-minimal package. Do not slim this image down
+# without replacing that probe mechanism.
 FROM registry.access.redhat.com/ubi10/ubi-minimal@sha256:f0ed153f25c9a3df530ccf2c49ec04430efef206083cbbc16ca76a866ef096b5 AS base
 COPY --from=openpolicyagent/opa:1.19.0-static@sha256:2f42ca765bb739b40fc23ee625b3287012acdf8120ad4fcbdab68433a17be144 /opa /opa
 

--- a/compose.yml
+++ b/compose.yml
@@ -53,6 +53,10 @@ services:
       - AA_BROKER_URL=sqs://localstack:4566
       - AA_SQS_URL=http://localstack:4566/000000000000/automated-actions
       - AA_DYNAMODB_URL=http://localstack:4566
+      # opa now defaults to a localhost-only sidecar in OpenShift (see
+      # openshift/template.yaml), but this compose file still runs it as its
+      # own container/service - point at it explicitly.
+      - AA_OPA_HOST=http://opa:8181
     build:
       context: .
       dockerfile: Dockerfile

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -138,6 +138,80 @@ objects:
               memory: ${{AA_API_MEMORY_REQUESTS}}
             limits:
               memory: ${{AA_API_MEMORY_LIMITS}}
+        # OPA sidecar: co-located in the api pod and bound to 127.0.0.1 only,
+        # so it is reachable exclusively from the web container above and
+        # never from another pod, even a co-tenant in the same namespace
+        # (OpenShift's default NetworkPolicy only blocks cross-namespace
+        # traffic, not same-namespace pod-to-pod traffic). This closes
+        # FIND-001 (APPSRE-14970) without needing a NetworkPolicy.
+        # httpGet/tcpSocket probes can't reach a loopback-only port from the
+        # kubelet, so probes here exec curl from inside the container instead.
+        - name: opa
+          image: "${OPA_IMAGE}:${IMAGE_TAG}"
+          args:
+          - run
+          - --ignore=.*
+          - --server
+          - --log-level=info
+          - --disable-telemetry
+          - --addr=127.0.0.1:${AA_OPA_PORT}
+          - --watch
+          - /authz # rego policy and default roles
+          - /policies # app-interface roles
+          envFrom:
+          - secretRef:
+              name: automated-actions-secret
+              optional: true
+          - configMapRef:
+              name: automated-actions-config
+              optional: true
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                - sh
+                - "-c"
+                - sleep 2
+          livenessProbe:
+            exec:
+              command:
+              - curl
+              - -sf
+              - http://127.0.0.1:${AA_OPA_PORT}/health
+            initialDelaySeconds: 5
+            periodSeconds: 60
+          readinessProbe:
+            # Include bundle activation in readiness
+            exec:
+              command:
+              - curl
+              - -sf
+              - http://127.0.0.1:${AA_OPA_PORT}/health?bundle=true
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          startupProbe:
+            exec:
+              command:
+              - curl
+              - -sf
+              - http://127.0.0.1:${AA_OPA_PORT}/health
+            initialDelaySeconds: 1
+            periodSeconds: 5
+            timeoutSeconds: 5
+          resources:
+            requests:
+              cpu: ${{AA_OPA_CPU_REQUESTS}}
+              memory: ${{AA_OPA_MEMORY_REQUESTS}}
+            limits:
+              memory: ${{AA_OPA_MEMORY_LIMITS}}
+          volumeMounts:
+          - name: policy-volume
+            mountPath: /policies
+            readOnly: true
+        volumes:
+        - name: policy-volume
+          configMap:
+            name: automated-actions-policy
 
 # ---------- API SERVICE -----------
 - apiVersion: v1
@@ -287,141 +361,6 @@ objects:
       app.kubernetes.io/component: worker
       app.kubernetes.io/name: automated-actions
 
-# ---------- Open Policy Agent (OPA) DEPLOYMENT --------------
-- apiVersion: policy/v1
-  kind: PodDisruptionBudget
-  metadata:
-    name: opa
-  spec:
-    minAvailable: 1
-    selector:
-      matchLabels:
-        app.kubernetes.io/component: opa
-
-- apiVersion: v1
-  kind: ServiceAccount
-  imagePullSecrets: "${{IMAGE_PULL_SECRETS}}"
-  metadata:
-    name: opa
-    labels:
-      app.kubernetes.io/component: opa
-      app.kubernetes.io/name: automated-actions
-
-- apiVersion: apps/v1
-  kind: Deployment
-  metadata:
-    annotations:
-      ignore-check.kube-linter.io/unset-cpu-requirements: "no cpu limits"
-    labels:
-      app.kubernetes.io/component: opa
-      app.kubernetes.io/name: automated-actions
-    name: opa
-  spec:
-    replicas: ${{AA_OPA_REPLICAS}}
-    selector:
-      matchLabels:
-        app.kubernetes.io/component: opa
-        app.kubernetes.io/name: automated-actions
-    template:
-      metadata:
-        labels:
-          app.kubernetes.io/component: opa
-          app.kubernetes.io/name: automated-actions
-      spec:
-        restartPolicy: Always
-        serviceAccountName: opa
-        affinity:
-          podAntiAffinity:
-            requiredDuringSchedulingIgnoredDuringExecution:
-            - labelSelector:
-                matchExpressions:
-                - key: app.kubernetes.io/component
-                  operator: In
-                  values:
-                  - opa
-              topologyKey: "kubernetes.io/hostname"
-        containers:
-        - name: opa
-          image: "${OPA_IMAGE}:${IMAGE_TAG}"
-          args:
-          - run
-          - --ignore=.*
-          - --server
-          - --log-level=info
-          - --disable-telemetry
-          - --addr=0.0.0.0:8181
-          - --watch
-          - /authz # rego policy and default roles
-          - /policies # app-interface roles
-          ports:
-          - name: http
-            containerPort: ${{AA_OPA_PORT}}
-          envFrom:
-          - secretRef:
-              name: automated-actions-secret
-              optional: true
-          - configMapRef:
-              name: automated-actions-config
-              optional: true
-          lifecycle:
-            preStop:
-              exec:
-                command:
-                - sh
-                - "-c"
-                - sleep 2
-          livenessProbe:
-            httpGet:
-              path: /health
-              scheme: HTTP
-              port: ${{AA_OPA_PORT}}
-            initialDelaySeconds: 5
-            periodSeconds: 60
-          readinessProbe:
-            httpGet:
-              path: /health?bundle=true # Include bundle activation in readiness
-              scheme: HTTP
-              port: ${{AA_OPA_PORT}}
-            initialDelaySeconds: 5
-            periodSeconds: 10
-          startupProbe:
-            tcpSocket:
-              port: ${{AA_OPA_PORT}}
-            initialDelaySeconds: 1
-            periodSeconds: 5
-            timeoutSeconds: 5
-          resources:
-            requests:
-              cpu: ${{AA_OPA_CPU_REQUESTS}}
-              memory: ${{AA_OPA_MEMORY_REQUESTS}}
-            limits:
-              memory: ${{AA_OPA_MEMORY_LIMITS}}
-          volumeMounts:
-          - name: policy-volume
-            mountPath: /policies
-            readOnly: true
-        volumes:
-        - name: policy-volume
-          configMap:
-            name: automated-actions-policy
-
-# ---------- Open Policy Agent (OPA) SERVICE --------------
-- apiVersion: v1
-  kind: Service
-  metadata:
-    labels:
-      app.kubernetes.io/component: opa
-      app.kubernetes.io/name: automated-actions
-    name: opa
-  spec:
-    ports:
-    - name: http
-      port: ${{AA_OPA_PORT}}
-      targetPort: ${{AA_OPA_PORT}}
-    selector:
-      app.kubernetes.io/component: opa
-      app.kubernetes.io/name: automated-actions
-
 parameters:
 # Global config
 - name: IMAGE
@@ -521,18 +460,13 @@ parameters:
   value: "100m"
   required: true
 
-# OPA config
+# OPA config (sidecar in the api pod, bound to 127.0.0.1 only)
 - name: AA_OPA_PORT
-  description: Port to expose the OPA app on
+  description: Port OPA listens on (loopback-only, no Service)
   value: "8181"
   required: true
 
-## OPA Pod limits
-- name: AA_OPA_REPLICAS
-  description: OPA replicas
-  value: "3"
-  required: true
-
+## OPA sidecar limits
 - name: AA_OPA_MEMORY_REQUESTS
   description: OPA memory requests
   value: "50Mi"

--- a/packages/automated_actions/automated_actions/config.py
+++ b/packages/automated_actions/automated_actions/config.py
@@ -57,7 +57,9 @@ class Settings(BaseSettings):
     token_secret: str
 
     # AuthZ
-    opa_host: str = "http://opa:8181"
+    # OPA runs as a sidecar bound to 127.0.0.1 in the api pod, not a separate
+    # Service - see openshift/template.yaml.
+    opa_host: str = "http://localhost:8181"
 
     # worker metrics config
     worker_metrics_port: int = 8000

--- a/settings.md
+++ b/settings.md
@@ -166,8 +166,8 @@ The OIDC client must have the following settings configured in the OIDC provider
 Settings for connecting to an OPA instance for authorization decisions.
 
 * **`AA_OPA_HOST`**:
-  * **Description**: The URL of the Open Policy Agent (OPA) server. The API server queries OPA to make authorization decisions.
-  * **Default**: `http://opa:8181`
+  * **Description**: The URL of the Open Policy Agent (OPA) server. The API server queries OPA to make authorization decisions. OPA runs as a sidecar bound to `127.0.0.1` in the same pod as the API, not a separate Service.
+  * **Default**: `http://localhost:8181`
   * **Impact**: If the API server cannot reach OPA, authorization checks will fail.
 
 * **`OPA_ACTION_API_URL`**:


### PR DESCRIPTION
## Summary
- Addresses [APPSRE-14970](https://redhat.atlassian.net/browse/APPSRE-14970) (Project Glasswing FIND-001): OPA previously ran as its own Deployment/Service on `0.0.0.0:8181`, reachable by any co-tenant pod in the namespace, with no `--authentication`/`--authorization` on its REST API - allowing an in-namespace attacker to overwrite the authz policy bundle.
- OPA is now a sidecar in the `automated-actions` (api) Deployment, bound to `127.0.0.1:8181` only. Since containers in a pod share the network namespace (including loopback), OPA is reachable exclusively from the `web` container in the same pod and never from another pod - no NetworkPolicy required.
- `httpGet`/`tcpSocket` probes can't reach a loopback-only port from the kubelet (it connects to the Pod IP from outside the pod's network namespace), so OPA's liveness/readiness/startup probes now `exec` `curl` from inside the container instead. `curl` comes from the `curl-minimal` package already present in the `ubi-minimal` base image used by `Dockerfile.opa` (commented there so it isn't accidentally stripped later).
- Removed the standalone `opa` Deployment/ServiceAccount/PodDisruptionBudget/Service and the now-unused `AA_OPA_REPLICAS` template parameter (OPA now scales 1:1 with the api pod).
- Updated `opa_host` default in `config.py` and its documentation in `settings.md` from `http://opa:8181` to `http://localhost:8181`.

## Test plan
- [x] `oc process --local -f openshift/template.yaml -p AA_URL=... -o yaml` renders cleanly; confirmed no standalone `opa` Deployment/Service remain and the sidecar container/volumes are correctly merged into the api Deployment.
- [x] `yamllint openshift/template.yaml` introduces no new issues beyond the file's pre-existing baseline.
- [x] `uv run pytest tests/auth/` (31 tests) passes.
- [x] `uv run ruff check` / `ruff format --check` / `mypy` pass on `config.py`.