### PR TITLE
fix(auth): add CSRF binding and open-redirect protection to OIDC callback

### DIFF
--- a/packages/automated_actions/automated_actions/auth.py
+++ b/packages/automated_actions/automated_actions/auth.py
@@ -1,10 +1,11 @@
 import logging
 import re
+import secrets
 from datetime import UTC
 from datetime import datetime as dt
 from json import JSONDecodeError
 from typing import TYPE_CHECKING, Any, Protocol, Self
-from urllib.parse import quote
+from urllib.parse import quote, urlsplit
 
 import httpxyz as httpx
 import jwt
@@ -17,6 +18,26 @@ if TYPE_CHECKING:
     from collections.abc import Iterable
 
 log = logging.getLogger(__name__)
+
+# How long a /login -> /callback round trip may take before the signed OIDC
+# state (and its matching cookie) is considered expired.
+OIDC_STATE_MAX_AGE_SECS = 600
+
+
+def _is_safe_next_url(next_url: str) -> bool:
+    r"""Only allow same-origin relative paths as post-login redirect targets.
+
+    Rejects absolute URLs and protocol-relative URLs (`//evil.com`) to prevent
+    open redirects. Backslashes are rejected too: some browsers normalize a
+    leading `/\` into `//`, turning it into a protocol-relative URL that
+    `urlsplit` alone would not catch.
+    """
+    if not next_url.startswith("/") or next_url.startswith("//"):
+        return False
+    if "\\" in next_url:
+        return False
+    parsed = urlsplit(next_url)
+    return not parsed.scheme and not parsed.netloc
 
 
 class AccessToken(BaseModel):
@@ -90,6 +111,11 @@ class OpenIDConnect[UserModel: UserModelProtocol]:
 
         self.session_serializer = URLSafeTimedSerializer(session_secret)
         self.session_timeout_secs = session_timeout_secs
+        # Separate salt so a leaked/forged state token can't be replayed as a
+        # session token (or vice versa) even though both share session_secret.
+        self.state_serializer = URLSafeTimedSerializer(
+            session_secret, salt="oidc-state"
+        )
 
     @classmethod
     async def create(
@@ -126,12 +152,15 @@ class OpenIDConnect[UserModel: UserModelProtocol]:
         )
 
     async def __call__(self, request: Request) -> UserModel:
+        next_url = request.url.path
+        if request.url.query:
+            next_url += f"?{request.url.query}"
         enforce_login = HTTPException(
             status_code=307,
             detail="Not authenticated",
             headers={
                 "Location": str(request.url_for("login"))
-                + f"?next_url={quote(str(request.url))}"
+                + f"?next_url={quote(next_url)}"
             },
         )
         session_token = request.cookies.get("session")
@@ -147,17 +176,50 @@ class OpenIDConnect[UserModel: UserModelProtocol]:
         raise enforce_login
 
     def login(self, request: Request, next_url: str = "") -> Response:
+        safe_next_url = next_url if _is_safe_next_url(next_url) else "/"
+        state_token = self.state_serializer.dumps({
+            "nonce": secrets.token_urlsafe(16),
+            "next_url": safe_next_url,
+        })
         auth_url = (
             f"{self.authorization_endpoint}?response_type=code"
             f"&scope={quote(self.scope)}"
             f"&client_id={quote(self.client_id)}"
             f"&redirect_uri={quote(str(request.url_for('callback')), safe='')}"
-            f"&state={quote(next_url)}"
+            f"&state={quote(state_token)}"
         )
-        return RedirectResponse(auth_url)
+        response = RedirectResponse(auth_url)
+        # Double-submit cookie: callback() only accepts a state that matches
+        # this cookie, binding the callback to the browser that started this
+        # specific login (RFC 6749 section 10.12 login-CSRF protection).
+        response.set_cookie(
+            key="oidc_state",
+            value=state_token,
+            secure=self.enforce_https,
+            httponly=True,
+            samesite="lax",
+            max_age=OIDC_STATE_MAX_AGE_SECS,
+        )
+        return response
 
     async def callback(self, request: Request, code: str, state: str) -> Response:
         """Keycloak callback."""
+        state_cookie = request.cookies.get("oidc_state")
+        if not state_cookie or state_cookie != state:
+            raise HTTPException(status_code=400, detail="Invalid or missing state")
+        try:
+            state_data = self.state_serializer.loads(
+                state, max_age=OIDC_STATE_MAX_AGE_SECS
+            )
+        except Exception as e:
+            raise HTTPException(
+                status_code=400, detail="Invalid or expired state"
+            ) from e
+
+        next_url = state_data.get("next_url", "/")
+        if not _is_safe_next_url(next_url):
+            next_url = "/"
+
         async with httpx.AsyncClient() as client:
             token_response = await client.post(
                 self.token_endpoint,
@@ -174,7 +236,8 @@ class OpenIDConnect[UserModel: UserModelProtocol]:
 
         token_data = token_response.json()
         session_token = self.session_serializer.dumps(token_data["access_token"])
-        response = RedirectResponse(url=state)
+        response = RedirectResponse(url=next_url)
+        response.delete_cookie("oidc_state")
         response.set_cookie(
             key="session",
             value=session_token,

--- a/packages/automated_actions/tests/auth/test_openid_connect.py
+++ b/packages/automated_actions/tests/auth/test_openid_connect.py
@@ -6,12 +6,14 @@ from datetime import datetime as dt
 from datetime import timedelta as td
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
+from urllib.parse import parse_qs, urlparse
 
 import jwt
 import pytest
 from fastapi import FastAPI, HTTPException, status
 from fastapi.routing import APIRoute
 from httpx import HTTPStatusError
+from starlette.datastructures import URL
 
 from automated_actions.auth import OpenIDConnect
 
@@ -92,6 +94,7 @@ async def test_openid_connect_call(
     mocker.patch.object(
         openid_connect, "get_user_info", return_value=usermodel.load("test_user")
     )
+    mock_request.url = URL("/")
     session = openid_connect.session_serializer.dumps("session_data")
     mock_request.cookies.get.return_value = session
     user_info = await openid_connect(mock_request)
@@ -104,7 +107,7 @@ async def test_openid_connect_call_no_session(
 ) -> None:
     mock_request.cookies.get.return_value = None
     mock_request.url_for.return_value = "/login"
-    mock_request.url = "/next"
+    mock_request.url = URL("/next")
     with pytest.raises(HTTPException) as exc_info:
         await openid_connect(mock_request)
     assert exc_info.value.status_code == status.HTTP_307_TEMPORARY_REDIRECT
@@ -118,7 +121,7 @@ async def test_openid_connect_call_bad_session(
 ) -> None:
     mock_request.cookies.get.return_value = None
     mock_request.url_for.return_value = "/login"
-    mock_request.url = "/next"
+    mock_request.url = URL("/next")
     mock_request.cookies.get.return_value = "invalid_session"
     with pytest.raises(HTTPException) as exc_info:
         await openid_connect(mock_request)
@@ -135,7 +138,7 @@ async def test_openid_connect_call_bad_token(
 ) -> None:
     mock_request.cookies.get.return_value = None
     mock_request.url_for.return_value = "/login"
-    mock_request.url = "/next"
+    mock_request.url = URL("/next")
 
     mocker.patch.object(
         openid_connect,
@@ -163,10 +166,33 @@ def test_openid_connect_login(
         "/api/v1/auth/login", params={"next_url": "/foobar"}, follow_redirects=False
     )
     assert response.status_code == status.HTTP_307_TEMPORARY_REDIRECT
-    assert (
-        response.headers["Location"]
-        == f"{openid_connect.authorization_endpoint}?response_type=code&scope=openid%20email%20profile&client_id=test_client_id&redirect_uri=http%3A%2F%2Ftestserver%2Fapi%2Fv1%2Fauth%2Fcallback&state=/foobar"
+
+    query = parse_qs(urlparse(response.headers["Location"]).query)
+    assert query["response_type"] == ["code"]
+    assert query["scope"] == ["openid email profile"]
+    assert query["client_id"] == ["test_client_id"]
+    assert query["redirect_uri"] == ["http://testserver/api/v1/auth/callback"]
+
+    state_token = query["state"][0]
+    assert response.cookies["oidc_state"] == state_token
+    state_data = openid_connect.state_serializer.loads(state_token)
+    assert state_data["next_url"] == "/foobar"
+
+
+def test_openid_connect_login_rejects_open_redirect(
+    openid_connect: OpenIDConnect,
+    full_app: FastAPI,
+    client: Callable[[FastAPI], TestClient],
+) -> None:
+    """FIND-003: an absolute/off-site next_url must not survive into state."""
+    response = client(full_app).get(
+        "/api/v1/auth/login",
+        params={"next_url": "https://evil.example.com"},
+        follow_redirects=False,
     )
+    state_token = parse_qs(urlparse(response.headers["Location"]).query)["state"][0]
+    state_data = openid_connect.state_serializer.loads(state_token)
+    assert state_data["next_url"] == "/"
 
 
 def test_openid_connect_callback_endpoint(
@@ -184,14 +210,21 @@ def test_openid_connect_callback_endpoint(
         json={"access_token": "not_a_real_token"},
     )
 
-    response = client(full_app).get(
+    test_client = client(full_app)
+    login_response = test_client.get(
+        "/api/v1/auth/login", params={"next_url": "/foobar"}, follow_redirects=False
+    )
+    state_token = login_response.cookies["oidc_state"]
+
+    response = test_client.get(
         "/api/v1/auth/callback",
-        params={"code": "test_code", "state": "/foobar"},
+        params={"code": "test_code", "state": state_token},
         follow_redirects=False,
     )
     assert response.status_code == status.HTTP_307_TEMPORARY_REDIRECT
     assert response.headers["Location"] == "/foobar"
     assert response.cookies["session"]
+    assert "oidc_state" not in response.cookies
 
 
 def test_openid_connect_callback_endpoint_error(
@@ -205,12 +238,51 @@ def test_openid_connect_callback_endpoint_error(
         status_code=status.HTTP_400_BAD_REQUEST,
     )
 
-    response = client(full_app).get(
+    test_client = client(full_app)
+    login_response = test_client.get(
+        "/api/v1/auth/login", params={"next_url": "/foobar"}, follow_redirects=False
+    )
+    state_token = login_response.cookies["oidc_state"]
+
+    response = test_client.get(
         "/api/v1/auth/callback",
-        params={"code": "test_code", "state": "/foobar"},
+        params={"code": "test_code", "state": state_token},
         follow_redirects=False,
     )
 
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+def test_openid_connect_callback_rejects_missing_state_cookie(
+    full_app: FastAPI,
+    client: Callable[[FastAPI], TestClient],
+) -> None:
+    """FIND-003: a callback with no matching oidc_state cookie is login-CSRF."""
+    response = client(full_app).get(
+        "/api/v1/auth/callback",
+        params={"code": "attacker_code", "state": "/foobar"},
+        follow_redirects=False,
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+def test_openid_connect_callback_rejects_tampered_state(
+    full_app: FastAPI,
+    client: Callable[[FastAPI], TestClient],
+) -> None:
+    """FIND-003: an unsigned state is rejected.
+
+    This holds even if an attacker manages to also set a matching cookie value.
+    """
+    test_client = client(full_app)
+    forged_state = "not-a-validly-signed-token"
+    test_client.cookies.set("oidc_state", forged_state)
+
+    response = test_client.get(
+        "/api/v1/auth/callback",
+        params={"code": "attacker_code", "state": forged_state},
+        follow_redirects=False,
+    )
     assert response.status_code == status.HTTP_400_BAD_REQUEST
 
 


### PR DESCRIPTION
## Summary
- Addresses [APPSRE-14972](https://redhat.atlassian.net/browse/APPSRE-14972) (Project Glasswing FIND-003): the OIDC `state` parameter carried the caller-supplied `next_url` verbatim, and `callback()` redirected to it without validating same-origin or binding it to the browser that started the login.
- **Open redirect**: any absolute or protocol-relative `next_url` (e.g. `https://evil.com`, `//evil.com`, or a backslash trick like `/\evil.com` that some browsers normalize into `//evil.com`) was honored as the post-login redirect target. Added `_is_safe_next_url()`, which only allows same-origin relative paths.
- **Login-CSRF (RFC 6749 §10.12)**: `state` was neither signed nor checked against anything set during `/login`, so an attacker could complete their own OAuth flow and trick a victim into visiting `/callback` with the attacker's `code`+`state`, logging the victim into the attacker's session. `/login` now signs a random-nonce'd state token (`itsdangerous`, separate salt from the session serializer) and sets it as an `httponly`, `samesite=lax`, 10-minute cookie; `/callback` rejects any request where the `state` param doesn't exactly match that cookie, or fails to verify/decode.
- `OpenIDConnect.__call__`'s own internal redirect-to-login (for unauthenticated requests) now builds `next_url` from `request.url.path`/`.query` instead of the full absolute URL, so it always produces a value that passes the new same-origin check.

## Test plan
- [x] Added two tests that first **prove both issues are exploitable** against the pre-fix code (forged `state` completes login with no prior `/login` call; `state` redirects off-site to `https://evil.example.com`) - confirmed they passed (i.e. reproduced the vulnerabilities) before implementing the fix, then confirmed they fail-safe (400) after.
- [x] Added regression tests: `test_openid_connect_login_rejects_open_redirect`, `test_openid_connect_callback_rejects_missing_state_cookie`, `test_openid_connect_callback_rejects_tampered_state`.
- [x] Updated `test_openid_connect_login`/`test_openid_connect_callback_endpoint(_error)` to exercise the real login→callback flow (signed state + cookie) instead of asserting on a raw, attacker-controllable `state` value.
- [x] `uv run pytest -q` in `packages/automated_actions` - 92/92 pass.
- [x] `uv run ruff check` / `ruff format --check` / `mypy` pass.