### PR TITLE
fix(auth): harden session cookie (HttpOnly, SameSite, server-side expiry)

### DIFF
--- a/packages/automated_actions/automated_actions/auth.py
+++ b/packages/automated_actions/automated_actions/auth.py
@@ -167,7 +167,9 @@ class OpenIDConnect[UserModel: UserModelProtocol]:
         if session_token:
             # already authenticated
             try:
-                access_token = self.session_serializer.loads(session_token)
+                access_token = self.session_serializer.loads(
+                    session_token, max_age=self.session_timeout_secs
+                )
                 return self.get_user_info(access_token)
             except Exception:
                 log.exception("Access token cannot be loaded or is outdated")
@@ -242,6 +244,8 @@ class OpenIDConnect[UserModel: UserModelProtocol]:
             key="session",
             value=session_token,
             secure=self.enforce_https,
+            httponly=True,
+            samesite="lax",
             expires=self.session_timeout_secs,
         )
         return response

--- a/packages/automated_actions/tests/auth/test_openid_connect.py
+++ b/packages/automated_actions/tests/auth/test_openid_connect.py
@@ -1,13 +1,15 @@
 # ruff: file-ignore[hardcoded-password-func-arg]
 
 
+import time
 from datetime import UTC
 from datetime import datetime as dt
 from datetime import timedelta as td
 from typing import TYPE_CHECKING
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 from urllib.parse import parse_qs, urlparse
 
+import itsdangerous
 import jwt
 import pytest
 from fastapi import FastAPI, HTTPException, status
@@ -329,3 +331,63 @@ def test_openid_connect_get_user_info_error(
     )
     with pytest.raises(HTTPStatusError):
         openid_connect.get_user_info("access_token")
+
+
+def test_openid_connect_callback_session_cookie_is_httponly_and_samesite(
+    openid_connect: OpenIDConnect,
+    full_app: FastAPI,
+    client: Callable[[FastAPI], TestClient],
+    httpx_mock: HTTPXMock,
+) -> None:
+    """FIND-004: the session cookie must not be readable from JS (XSS mitigation)."""
+    httpx_mock.add_response(
+        url=openid_connect.token_endpoint,
+        json={"access_token": "not_a_real_token"},
+    )
+    test_client = client(full_app)
+    login_response = test_client.get(
+        "/api/v1/auth/login", params={"next_url": "/foobar"}, follow_redirects=False
+    )
+    state_token = login_response.cookies["oidc_state"]
+    response = test_client.get(
+        "/api/v1/auth/callback",
+        params={"code": "test_code", "state": state_token},
+        follow_redirects=False,
+    )
+    session_cookie_header = next(
+        h for h in response.headers.get_list("set-cookie") if h.startswith("session=")
+    )
+    assert "httponly" in session_cookie_header.lower()
+    assert "samesite=lax" in session_cookie_header.lower()
+
+
+@pytest.mark.asyncio
+async def test_openid_connect_call_rejects_expired_session(
+    openid_connect: OpenIDConnect,
+    mock_request: MagicMock,
+    mocker: MockerFixture,
+    usermodel: MockUserModel,
+) -> None:
+    """FIND-004: a session older than session_timeout_secs must be rejected.
+
+    This must be enforced server-side, not just via the cookie's client-enforced
+    expiry.
+    """
+    mocker.patch.object(
+        openid_connect, "get_user_info", return_value=usermodel.load("test_user")
+    )
+    mock_request.url = URL("/")
+    mock_request.url_for.return_value = "/login"
+    # Only fake the clock while dumping, so loads() compares against the real
+    # current time and actually sees the token as stale.
+    with patch.object(
+        itsdangerous.TimestampSigner,
+        "get_timestamp",
+        return_value=int(time.time()) - openid_connect.session_timeout_secs - 1,
+    ):
+        stale_session = openid_connect.session_serializer.dumps("session_data")
+    mock_request.cookies.get.return_value = stale_session
+
+    with pytest.raises(HTTPException) as exc_info:
+        await openid_connect(mock_request)
+    assert exc_info.value.status_code == status.HTTP_307_TEMPORARY_REDIRECT


### PR DESCRIPTION
## Summary
Addresses [APPSRE-14973](https://redhat.atlassian.net/browse/APPSRE-14973) (Project Glasswing FIND-004).

**Stacked on #723** (FIND-003) - this branch is built on top of it since both touch the same `callback()`/session flow and these tests build on the login→callback cookie flow introduced there. The diff below currently includes #723's changes too; once #723 merges into `main` this PR will automatically show only the incremental FIND-004 diff.

- `set_cookie()` for the `session` cookie didn't set `httponly`, so any XSS (or the FastAPI `/docs` UI) could read the signed session blob out of `document.cookie` and replay the access_token elsewhere. Added `httponly=True`. (`samesite` was already defaulting to `"lax"` in the Starlette version in use - confirmed via `inspect.signature` - but it's now set explicitly for clarity and to not depend on a framework default.)
- `session_serializer.loads()` was called without `max_age`, so a captured cookie stayed valid server-side indefinitely - `session_timeout_secs` was only ever enforced by the client honoring the cookie's own expiry. Added `max_age=self.session_timeout_secs` so an expired-but-still-validly-signed token is rejected server-side too.

## Test plan
- [x] Added a test that first **proved the expiry gap** pre-fix (a session token older than `session_timeout_secs`, produced via a clock mock scoped only to the `dumps()` call so `loads()` compares against the real current time, was still accepted) - confirmed it passed against the old code, then confirmed it now correctly gets rejected with a 307 redirect-to-login.
- [x] Added a test confirming the `session` cookie's `Set-Cookie` header includes both `httponly` and `samesite=lax`.
- [x] `uv run pytest -q` in `packages/automated_actions` - 94/94 pass.
- [x] `uv run ruff check` / `ruff format --check` / `mypy` pass.
- [x] Confirmed no env vars or docker-compose topology changes needed - this is pure application logic.