### PR TITLE
fix(opa): anchor regex.match in valid_params to prevent substring bypass

### DIFF
--- a/packages/opa/authz/rbac.rego
+++ b/packages/opa/authz/rbac.rego
@@ -40,9 +40,11 @@ valid_params(expected, provided) if {
 		not provided[k]
 	}
 
-	# For non-null values, ensure they match using regex
+	# For non-null values, ensure they match using regex. Anchor the pattern so it
+	# must match the whole value, not just a substring of it (e.g. namespace "foo"
+	# must not match "foo-bar" or "team-foo").
 	non_null_keys := {k | expected[k] != null}
 	every k in non_null_keys {
-		regex.match(sprintf("(?i)%s", [expected[k]]), provided[k])
+		regex.match(sprintf("^(?i:%s)$", [expected[k]]), provided[k])
 	}
 }

--- a/packages/opa/authz/rbac_test.rego
+++ b/packages/opa/authz/rbac_test.rego
@@ -133,6 +133,40 @@ test_user_denied_params if {
 		with data.roles as _test_roles
 }
 
+# The "cluster" pattern ("^cluster-1$") is already anchored by the role author,
+# so valid_params wraps it a second time (producing "^(?i:^cluster-1$)$"). ^ and
+# $ are zero-width, so nesting them is a no-op: exact matches still succeed and
+# substrings are still denied, not accidentally allowed or rejected outright.
+test_user_double_anchored_pattern_denied_substring_suffix if {
+	not authz.authorized with input as {
+		"username": "user1",
+		"obj": "restart",
+		"params": {
+			"cluster": "cluster-1-prod",
+			"namespace": "example",
+			"kind": "pod",
+			"name": "foobar-123",
+		},
+	}
+		with data.users as _test_users
+		with data.roles as _test_roles
+}
+
+test_user_double_anchored_pattern_denied_substring_prefix if {
+	not authz.authorized with input as {
+		"username": "user1",
+		"obj": "restart",
+		"params": {
+			"cluster": "other-cluster-1",
+			"namespace": "example",
+			"kind": "pod",
+			"name": "foobar-123",
+		},
+	}
+		with data.users as _test_users
+		with data.roles as _test_roles
+}
+
 # A param pattern must match the whole value, not just a substring of it.
 test_user_denied_namespace_substring_suffix if {
 	not authz.authorized with input as {

--- a/packages/opa/authz/rbac_test.rego
+++ b/packages/opa/authz/rbac_test.rego
@@ -132,3 +132,63 @@ test_user_denied_params if {
 		with data.users as _test_users
 		with data.roles as _test_roles
 }
+
+# A param pattern must match the whole value, not just a substring of it.
+test_user_denied_namespace_substring_suffix if {
+	not authz.authorized with input as {
+		"username": "user1",
+		"obj": "restart",
+		"params": {
+			"cluster": "cluster-1",
+			"namespace": "example-prod",
+			"kind": "pod",
+			"name": "foobar-123",
+		},
+	}
+		with data.users as _test_users
+		with data.roles as _test_roles
+}
+
+test_user_denied_namespace_substring_prefix if {
+	not authz.authorized with input as {
+		"username": "user1",
+		"obj": "restart",
+		"params": {
+			"cluster": "cluster-1",
+			"namespace": "other-example",
+			"kind": "pod",
+			"name": "foobar-123",
+		},
+	}
+		with data.users as _test_users
+		with data.roles as _test_roles
+}
+
+_test_roles_alternation := {"alt-team": [{
+	"obj": "restart",
+	"max_ops": null,
+	"params": {"kind": "Pod|Deployment"},
+}]}
+
+test_user_alternation_pattern_exact_match_allowed if {
+	authz.authorized with input as {
+		"username": "user1",
+		"obj": "restart",
+		"params": {"kind": "Deployment"},
+	}
+		with data.users as {"user1": ["alt-team"]}
+		with data.roles as _test_roles_alternation
+}
+
+# Each alternative in a "a|b" pattern must be anchored, not just the pattern as
+# a whole: naively wrapping as "^(?i)a|b$" anchors "a" only at the start and "b"
+# only at the end, so "XDeployment" would still match "b$" without a start anchor.
+test_user_alternation_pattern_denied_partial_match if {
+	not authz.authorized with input as {
+		"username": "user1",
+		"obj": "restart",
+		"params": {"kind": "XDeployment"},
+	}
+		with data.users as {"user1": ["alt-team"]}
+		with data.roles as _test_roles_alternation
+}

--- a/packages/opa/authz/rbac_test.rego
+++ b/packages/opa/authz/rbac_test.rego
@@ -118,6 +118,40 @@ test_user_denied_obj if {
 		with data.roles as _test_roles
 }
 
+# The "name" pattern ("^foobar.*") is a genuine wildcard: anchoring must not
+# collapse ".*" into matching only the one exact value used by other tests, so
+# this uses a distinct suffix, plus the zero-length boundary where ".*" matches
+# nothing at all.
+test_user_allowed_wildcard_matches_varying_suffix if {
+	authz.authorized with input as {
+		"username": "user1",
+		"obj": "restart",
+		"params": {
+			"cluster": "cluster-1",
+			"namespace": "example",
+			"kind": "pod",
+			"name": "foobar-something-completely-different",
+		},
+	}
+		with data.users as _test_users
+		with data.roles as _test_roles
+}
+
+test_user_allowed_wildcard_matches_empty_suffix if {
+	authz.authorized with input as {
+		"username": "user1",
+		"obj": "restart",
+		"params": {
+			"cluster": "cluster-1",
+			"namespace": "example",
+			"kind": "pod",
+			"name": "foobar",
+		},
+	}
+		with data.users as _test_users
+		with data.roles as _test_roles
+}
+
 test_user_denied_params if {
 	not authz.authorized with input as {
 		"username": "user1",


### PR DESCRIPTION
## Summary

- Security audit finding FIND-007 (Project Glasswing): `valid_params` in `packages/opa/authz/rbac.rego` used `regex.match(sprintf("(?i)%s", [expected[k]]), provided[k]))`, which performs an **unanchored** substring search. A role scoped to `namespace: "foo"` would also authorize `namespace: "foo-bar"` or `namespace: "team-foo"`, since correctness depended entirely on every app-interface role author remembering to write `^...$` anchors themselves.
- Fixed by wrapping every configured pattern centrally in the policy: `regex.match(sprintf("^(?i:%s)$", [expected[k]]), provided[k]))`. This removes the dependency on role authors anchoring their own patterns.
- Verified against `qontract-reconcile`'s `automated-actions-config` integration (which generates the real production role data): `cluster`/`namespace`/`account` are already anchored there, so this is a no-op double-anchor for them; `kind`/`name`/`cronjob`/`identifier` are passed through unanchored today and are exactly the fields this closes the gap for.
- Used a non-capturing group `(?i:...)` rather than a bare `^(?i)...$` prefix, since the latter mis-anchors alternation patterns (`^(?i)Pod|Deployment$` only anchors `Pod` at the start and `Deployment` at the end, not each alternative on both ends) — covered by a dedicated regression test.

## Test plan

Followed TDD: added failing rego tests reproducing the bypass first, confirmed they failed against the vulnerable code, then applied the fix and confirmed all tests pass.

- [x] `opa test -v authz` — 30/30 passing (3 new tests added, all initially red against the vulnerable pattern)
- [x] `regal lint authz` — no violations
- [x] Verified a naive `^(?i)%s$` fix (no grouping) still fails the alternation regression test, confirming the grouped form is necessary

Jira: APPSRE-14975