### PR TITLE
fix(auth): scope action-detail/action-cancel to the action's own owner

### DIFF
--- a/packages/automated_actions/automated_actions/api/v1/__init__.py
+++ b/packages/automated_actions/automated_actions/api/v1/__init__.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, Depends
 
 from .dependencies import get_authz, get_user
+from .views.action import owner_scoped_router as action_owner_scoped_router
 from .views.action import router as action_router
 from .views.admin import router as admin_router
 from .views.external_resource import router as external_resource_router
@@ -21,5 +22,8 @@ router.include_router(
 router.include_router(
     action_router, dependencies=[Depends(get_user), Depends(get_authz)]
 )
+# action-detail/action-cancel authorize themselves via get_authorized_action
+# (which injects the action's owner into the OPA call), not the generic get_authz.
+router.include_router(action_owner_scoped_router, dependencies=[Depends(get_user)])
 router.include_router(user_router, dependencies=[Depends(get_authz)])
 router.include_router(no_op_router, dependencies=[Depends(get_authz)])

--- a/packages/automated_actions/automated_actions/api/v1/dependencies.py
+++ b/packages/automated_actions/automated_actions/api/v1/dependencies.py
@@ -30,3 +30,10 @@ async def get_authz(request: Request, user: UserDep) -> OPA:
 
 
 AuthZDep = Annotated[OPA, Depends(get_authz)]
+
+
+def get_opa_instance(request: Request) -> OPA:
+    return request.app.state.authz
+
+
+OpaInstanceDep = Annotated[OPA, Depends(get_opa_instance)]

--- a/packages/automated_actions/automated_actions/api/v1/views/action.py
+++ b/packages/automated_actions/automated_actions/api/v1/views/action.py
@@ -1,17 +1,40 @@
 import logging
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, Query, Request
 
-from automated_actions.api.v1.dependencies import UserDep
+from automated_actions.api.v1.dependencies import OpaInstanceDep, UserDep
 from automated_actions.db.models import (
+    Action,
     ActionSchemaOut,
     ActionStatus,
 )
 from automated_actions.db.models._action import ActionManager, get_action_manager
 
 router = APIRouter()
+# action-detail/action-cancel authorize via get_authorized_action (which performs
+# its own OPA call with the action's owner) instead of the generic router-level
+# authz dependency, so they get their own router.
+owner_scoped_router = APIRouter()
 log = logging.getLogger(__name__)
+
+
+async def get_authorized_action(
+    request: Request,
+    user: UserDep,
+    authz: OpaInstanceDep,
+    action_id: str,
+    action_mgr: Annotated[ActionManager, Depends(get_action_manager)],
+) -> Action:
+    """Fetch the action and authorize access to it, scoped by its owner.
+
+    OPA's default role only allows a user to act on their own actions; the
+    action's owner isn't part of the request (unlike action-list's action_user
+    filter), so it has to be looked up here and passed to OPA explicitly.
+    """
+    action = action_mgr.get_or_404(action_id)
+    await authz(request, user, extra_params={"owner": action.owner})
+    return action
 
 
 @router.get(
@@ -50,28 +73,27 @@ def action_list(
     ]
 
 
-@router.get(
+@owner_scoped_router.get(
     "/actions/{action_id}",
     operation_id="action-detail",
     tags=["General"],
 )
 def action_detail(
-    action_id: str, action_mgr: Annotated[ActionManager, Depends(get_action_manager)]
+    action: Annotated[Action, Depends(get_authorized_action)],
 ) -> ActionSchemaOut:
     """Retrieves the details of a specific action by its ID."""
-    return action_mgr.get_or_404(action_id).dump()
+    return action.dump()
 
 
-@router.post(
+@owner_scoped_router.post(
     "/actions/{action_id}",
     operation_id="action-cancel",
     status_code=202,
     tags=["General"],
 )
 def action_cancel(
-    action_id: str, action_mgr: Annotated[ActionManager, Depends(get_action_manager)]
+    action: Annotated[Action, Depends(get_authorized_action)],
 ) -> ActionSchemaOut:
     """Cancels a pending or running action by its ID."""
-    action = action_mgr.get_or_404(action_id)
     action.set_status(ActionStatus.CANCELLED)
     return action.dump()

--- a/packages/automated_actions/automated_actions/auth.py
+++ b/packages/automated_actions/automated_actions/auth.py
@@ -339,7 +339,12 @@ class OPA[UserModel: UserModelProtocol]:
                 detail="Action rate limit exceeded!",
             )
 
-    async def __call__(self, request: Request, user: UserModel) -> None:
+    async def __call__(
+        self,
+        request: Request,
+        user: UserModel,
+        extra_params: dict[str, str] | None = None,
+    ) -> None:
         # allow endpoints without authorization
         if self.should_skip_endpoint(request.url.path):
             return
@@ -347,6 +352,8 @@ class OPA[UserModel: UserModelProtocol]:
         # check if user is authorized to access endpoint
         params = request.path_params.copy()
         params.update(request.query_params)
+        if extra_params:
+            params.update(extra_params)
         opa_data = await self.query_opa(
             user, obj=request["route"].operation_id, params=params
         )

--- a/packages/automated_actions/pyproject.toml
+++ b/packages/automated_actions/pyproject.toml
@@ -114,6 +114,17 @@ ignore = [
 [tool.ruff.format]
 preview = true
 
+[tool.ruff.lint.per-file-ignores]
+"tests/**" = [
+    "hardcoded-password-string",    # tests use fake secrets/tokens
+    "hardcoded-password-func-arg",
+    "import-outside-top-level",    # tests import lazily to control env var/mock setup timing
+    "unused-class-method-argument",    # test stub/fake classes match a wider interface
+    "unnecessary-dunder-call",    # TestClient.__enter__() usage
+    "magic-value-comparison",
+    "unused-async",    # async test doubles matching an async interface (e.g. OPA.__call__)
+]
+
 [tool.ruff.lint.isort]
 known-first-party = ["automated_actions"]
 

--- a/packages/automated_actions/tests/api/v1/views/test_action.py
+++ b/packages/automated_actions/tests/api/v1/views/test_action.py
@@ -1,12 +1,12 @@
-# ruff: file-ignore[unused-class-method-argument]
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import pytest
-from fastapi import FastAPI, status
+from fastapi import FastAPI, HTTPException, status
 from pynamodb.attributes import DynamicMapAttribute
 
+from automated_actions.api.v1.dependencies import get_opa_instance, get_user
 from automated_actions.db.models import (
     ActionManager,
     ActionSchemaOut,
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
     from fastapi.testclient import TestClient
 
     from automated_actions.db.models._action import ActionSchemaIn
+    from tests.conftest import MockUserModel
 
 
 class ActionStub(ActionSchemaOut):
@@ -161,3 +162,70 @@ def test_action_cancel(
     )
     assert response.status_code == status.HTTP_202_ACCEPTED
     assert response.json()["status"] == ActionStatus.CANCELLED
+
+
+def _make_owner_enforcing_authz(calls: list[dict[str, Any]]) -> Callable:
+    """Stand-in for OPA: records each call and denies if owner != caller."""
+
+    async def _authz(
+        _request: Any, user: Any, extra_params: dict[str, str] | None = None
+    ) -> None:
+        calls.append({"username": user.username, "extra_params": extra_params})
+        if extra_params and extra_params.get("owner") != user.username:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED, detail="Not authorized"
+            )
+
+    return _authz
+
+
+@pytest.mark.parametrize(
+    ("method", "operation_id"),
+    [("get", "action_detail"), ("post", "action_cancel")],
+)
+def test_action_detail_and_cancel_pass_action_owner_to_authz(
+    testing_app: FastAPI,
+    client: Callable[[FastAPI], TestClient],
+    method: str,
+    operation_id: str,
+) -> None:
+    """ActionStub("1").owner == "test_user" == the default fake user's username."""
+    calls: list[dict[str, Any]] = []
+    testing_app.dependency_overrides[get_opa_instance] = lambda: (
+        _make_owner_enforcing_authz(calls)
+    )
+
+    response = getattr(client(testing_app), method)(
+        testing_app.url_path_for(operation_id, action_id="1"),
+    )
+
+    assert response.status_code in {status.HTTP_200_OK, status.HTTP_202_ACCEPTED}
+    assert calls == [{"username": "test_user", "extra_params": {"owner": "test_user"}}]
+
+
+@pytest.mark.parametrize(
+    ("method", "operation_id"),
+    [("get", "action_detail"), ("post", "action_cancel")],
+)
+def test_action_detail_and_cancel_deny_other_users_action(
+    testing_app: FastAPI,
+    client: Callable[[FastAPI], TestClient],
+    usermodel: type[MockUserModel],
+    method: str,
+    operation_id: str,
+) -> None:
+    """FIND-005: a user must not be able to view/cancel another user's action."""
+    calls: list[dict[str, Any]] = []
+    testing_app.dependency_overrides[get_opa_instance] = lambda: (
+        _make_owner_enforcing_authz(calls)
+    )
+    testing_app.dependency_overrides[get_user] = lambda: usermodel(
+        username="other_user"
+    )
+
+    response = getattr(client(testing_app), method)(
+        testing_app.url_path_for(operation_id, action_id="1"),
+    )
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+    assert calls == [{"username": "other_user", "extra_params": {"owner": "test_user"}}]

--- a/packages/automated_actions/tests/auth/test_bearer_token_auth.py
+++ b/packages/automated_actions/tests/auth/test_bearer_token_auth.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 def bearer_token_auth(usermodel: type) -> BearerTokenAuth:
     return BearerTokenAuth[usermodel](  # type: ignore[valid-type]
         issuer="http://dev.com",
-        secret="secret",  # ruff: ignore[hardcoded-password-func-arg]
+        secret="secret",
         user_model=usermodel,
     )
 

--- a/packages/automated_actions/tests/auth/test_opa.py
+++ b/packages/automated_actions/tests/auth/test_opa.py
@@ -123,6 +123,37 @@ async def test_opa_call(
 
 
 @pytest.mark.asyncio
+async def test_opa_call_with_extra_params(
+    opa: OPA, usermodel: MockUserModel, mock_request: MagicMock, httpx_mock: HTTPXMock
+) -> None:
+    """extra_params (e.g. an action's owner) must be merged into the params sent to OPA."""
+    user = usermodel.load("test_user")
+    route_mock = MagicMock()
+    route_mock.operation_id = "action-detail"
+    mock_request.__getitem__.return_value = route_mock
+    mock_request.path_params = {"action_id": "1"}
+    mock_request.url = MagicMock()
+    mock_request.url.path = "/actions/1"
+
+    httpx_mock.add_response(
+        method="POST",
+        match_json={
+            "input": {
+                "username": "test_user",
+                "name": "test user",
+                "email": "test@example.com",
+                "created_at": 1,
+                "updated_at": 2,
+                "obj": "action-detail",
+                "params": {"action_id": "1", "owner": "test_user"},
+            }
+        },
+        json={"result": {"authorized": True, "within_rate_limits": True}},
+    )
+    await opa(request=mock_request, user=user, extra_params={"owner": "test_user"})
+
+
+@pytest.mark.asyncio
 async def test_opa_call_skipped(
     opa: OPA, usermodel: MockUserModel, mock_request: MagicMock
 ) -> None:

--- a/packages/automated_actions/tests/auth/test_openid_connect.py
+++ b/packages/automated_actions/tests/auth/test_openid_connect.py
@@ -1,6 +1,3 @@
-# ruff: file-ignore[hardcoded-password-func-arg]
-
-
 import time
 from datetime import UTC
 from datetime import datetime as dt
@@ -74,7 +71,7 @@ def test_openid_connect_init_endpoints(openid_connect: OpenIDConnect) -> None:
 
 
 def test_openid_connect_init_router(openid_connect: OpenIDConnect) -> None:
-    assert len(openid_connect.router.routes) == 3  # ruff: ignore[magic-value-comparison]
+    assert len(openid_connect.router.routes) == 3
     assert isinstance(openid_connect.router.routes[0], APIRoute)
     assert openid_connect.router.routes[0].path == "/login"
     assert openid_connect.router.routes[0].endpoint == openid_connect.login

--- a/packages/automated_actions/tests/celery/conftest.py
+++ b/packages/automated_actions/tests/celery/conftest.py
@@ -27,4 +27,4 @@ def mock_action(mocker: MockerFixture) -> Mock:
 
 @pytest.fixture
 def cluster_connection_data() -> ClusterConnectionData:
-    return ClusterConnectionData(url="url", token="token")  # ruff: ignore[hardcoded-password-func-arg]
+    return ClusterConnectionData(url="url", token="token")

--- a/packages/automated_actions/tests/celery/test_external_resource.py
+++ b/packages/automated_actions/tests/celery/test_external_resource.py
@@ -79,7 +79,7 @@ def test_external_resource_rds_reboot_task(
         "automated_actions.celery.external_resource.tasks.get_aws_credentials",
         return_value=AWSStaticCredentials(
             access_key_id="test-access-key",
-            secret_access_key="test-secret-key",  # ruff: ignore[hardcoded-password-func-arg]
+            secret_access_key="test-secret-key",
             region="us-west-2",
         ),
     )
@@ -114,7 +114,7 @@ def test_external_resource_rds_reboot_task_non_retryable_failure(
         "automated_actions.celery.external_resource.tasks.get_aws_credentials",
         return_value=AWSStaticCredentials(
             access_key_id="test-access-key",
-            secret_access_key="test-secret-key",  # ruff: ignore[hardcoded-password-func-arg]
+            secret_access_key="test-secret-key",
             region="us-west-2",
         ),
     )
@@ -195,7 +195,7 @@ def test_external_resource_rds_start_task(
         "automated_actions.celery.external_resource.tasks.get_aws_credentials",
         return_value=AWSStaticCredentials(
             access_key_id="test-access-key",
-            secret_access_key="test-secret-key",  # ruff: ignore[hardcoded-password-func-arg]
+            secret_access_key="test-secret-key",
             region="us-west-2",
         ),
     )
@@ -228,7 +228,7 @@ def test_external_resource_rds_start_task_non_retryable_failure(
         "automated_actions.celery.external_resource.tasks.get_aws_credentials",
         return_value=AWSStaticCredentials(
             access_key_id="test-access-key",
-            secret_access_key="test-secret-key",  # ruff: ignore[hardcoded-password-func-arg]
+            secret_access_key="test-secret-key",
             region="us-west-2",
         ),
     )
@@ -307,7 +307,7 @@ def test_external_resource_rds_stop_task(
         "automated_actions.celery.external_resource.tasks.get_aws_credentials",
         return_value=AWSStaticCredentials(
             access_key_id="test-access-key",
-            secret_access_key="test-secret-key",  # ruff: ignore[hardcoded-password-func-arg]
+            secret_access_key="test-secret-key",
             region="us-west-2",
         ),
     )
@@ -340,7 +340,7 @@ def test_external_resource_rds_stop_task_non_retryable_failure(
         "automated_actions.celery.external_resource.tasks.get_aws_credentials",
         return_value=AWSStaticCredentials(
             access_key_id="test-access-key",
-            secret_access_key="test-secret-key",  # ruff: ignore[hardcoded-password-func-arg]
+            secret_access_key="test-secret-key",
             region="us-west-2",
         ),
     )
@@ -381,7 +381,7 @@ def test_external_resource_flush_elasticache_run(
         image="test-image",
         command=["test-command"],
         args=["arg1"],
-        secret_name="test-secret",  # ruff: ignore[hardcoded-password-func-arg]
+        secret_name="test-secret",
         env_secret_mappings={"ENV_VAR": "test-key"},
     )
 
@@ -399,7 +399,7 @@ def test_external_resource_flush_elasticache_task(
         "automated_actions.celery.external_resource.tasks.get_cluster_connection_data",
         return_value=ClusterConnectionData(
             url="https://test-cluster-url",
-            token="test-cluster-token",  # ruff: ignore[hardcoded-password-func-arg]
+            token="test-cluster-token",
         ),
     )
     mocker.patch(
@@ -437,7 +437,7 @@ def test_external_resource_flush_elasticache_task_non_retryable_failure(
         "automated_actions.celery.external_resource.tasks.get_cluster_connection_data",
         return_value=ClusterConnectionData(
             url="https://test-cluster-url",
-            token="test-cluster-token",  # ruff: ignore[hardcoded-password-func-arg]
+            token="test-cluster-token",
         ),
     )
     mocker.patch(

--- a/packages/automated_actions/tests/conftest.py
+++ b/packages/automated_actions/tests/conftest.py
@@ -1,4 +1,3 @@
-# ruff: file-ignore[hardcoded-password-string, hardcoded-password-func-arg, import-outside-top-level]
 import os
 from typing import TYPE_CHECKING, Any, Self
 
@@ -62,6 +61,16 @@ def get_authz_fake() -> Callable:
 
 
 @pytest.fixture
+def get_opa_instance_fake() -> Callable:
+    async def _noop_authz(*_: Any, **__: Any) -> None: ...
+
+    def _get_opa_instance() -> Callable:
+        return _noop_authz
+
+    return _get_opa_instance
+
+
+@pytest.fixture
 def full_app(httpx_mock: HTTPXMock) -> FastAPI:
     """FastAPI app with authentication and authorization setup but without DynamoDB."""
     from automated_actions.app_factory import create_app
@@ -80,16 +89,26 @@ def full_app(httpx_mock: HTTPXMock) -> FastAPI:
 
 
 @pytest.fixture
-def app(get_user_fake: Callable, get_authz_fake: Callable, usermodel: type) -> FastAPI:
+def app(
+    get_user_fake: Callable,
+    get_authz_fake: Callable,
+    get_opa_instance_fake: Callable,
+    usermodel: type,
+) -> FastAPI:
     """FastAPI app without authentication, authorization, and DynamoDB."""
     # import here to have all os.env variables set before importing the settings module
-    from automated_actions.api.v1.dependencies import get_authz, get_user
+    from automated_actions.api.v1.dependencies import (
+        get_authz,
+        get_opa_instance,
+        get_user,
+    )
     from automated_actions.app_factory import create_app
     from automated_actions.auth import BearerTokenAuth
 
     test_app = create_app(run_db_init=False, run_auth_init=False)
     test_app.dependency_overrides[get_user] = get_user_fake
     test_app.dependency_overrides[get_authz] = get_authz_fake
+    test_app.dependency_overrides[get_opa_instance] = get_opa_instance_fake
     test_app.state.token = BearerTokenAuth[usermodel](  # type: ignore[valid-type]
         issuer="http://dev.com", secret="fake", user_model=usermodel
     )
@@ -102,7 +121,7 @@ def client() -> Callable[[FastAPI], TestClient]:
 
     def _client(app: FastAPI) -> TestClient:
         client = TestClient(app)
-        client.__enter__()  # ruff: ignore[unnecessary-dunder-call]
+        client.__enter__()
         return client
 
     return _client

--- a/packages/automated_actions/tests/db/test_model_action.py
+++ b/packages/automated_actions/tests/db/test_model_action.py
@@ -1,4 +1,3 @@
-# ruff: file-ignore[unused-class-method-argument]
 from __future__ import annotations
 
 import pytest

--- a/packages/automated_actions/tests/test_config.py
+++ b/packages/automated_actions/tests/test_config.py
@@ -1,7 +1,5 @@
 def test_config_import_settings() -> None:
-    from automated_actions.config import (  # ruff: ignore[import-outside-top-level]
-        settings,
-    )
+    from automated_actions.config import settings
 
     # we don't need to test all settings because ruff and mypy will do that for us
     assert settings.environment == "unit_tests"

--- a/packages/opa/authz/default_roles.yml
+++ b/packages/opa/authz/default_roles.yml
@@ -15,10 +15,12 @@ roles:
       action_user: null
   - obj: action-detail
     max_ops: null
-    params: {}
+    params:
+      owner: "$username"
   - obj: action-cancel
     max_ops: null
-    params: {}
+    params:
+      owner: "$username"
   opa:
   # the OPA service account must be allowed to retrieve the actions for any user!
   - obj: action-list

--- a/packages/opa/authz/rbac.rego
+++ b/packages/opa/authz/rbac.rego
@@ -23,7 +23,7 @@ authorized if {
 check_role_permissions(role_permissions, username, current_input_obj, current_input_params) if {
 	some permission in role_permissions
 	object_matches(permission.obj, current_input_obj)
-	valid_params(permission.params, current_input_params)
+	valid_params(permission.params, current_input_params, username)
 }
 
 # Match any input if permission_obj is "*"
@@ -33,18 +33,26 @@ object_matches(permission_obj, input_obj) if {
 	permission_obj == input_obj
 }
 
-valid_params(expected, provided) if {
+valid_params(expected, provided, username) if {
 	# Check that null values in expected mean that the key should not be present in provided
 	null_keys := {k | expected[k] == null}
 	every k in null_keys {
 		not provided[k]
 	}
 
-	# For non-null values, ensure they match using regex. Anchor the pattern so it
-	# must match the whole value, not just a substring of it (e.g. namespace "foo"
-	# must not match "foo-bar" or "team-foo").
+	# For non-null values, ensure they match (either against the caller's own
+	# username, or as a regex, see param_matches)
 	non_null_keys := {k | expected[k] != null}
 	every k in non_null_keys {
-		regex.match(sprintf("^(?i:%s)$", [expected[k]]), provided[k])
+		param_matches(expected[k], provided[k], username)
 	}
+}
+
+# "$username" means the param must equal the caller's own username, e.g. to scope
+# a role to only the actions it owns rather than a fixed, per-role pattern.
+param_matches("$username", value, username) if value == username
+
+param_matches(pattern, value, _) if {
+	pattern != "$username"
+	regex.match(sprintf("^(?i:%s)$", [pattern]), value)
 }

--- a/packages/opa/authz/rbac_default_roles_test.rego
+++ b/packages/opa/authz/rbac_default_roles_test.rego
@@ -26,19 +26,37 @@ test_default_action_list_action_user_param_not_allowed if {
 	}
 }
 
-test_default_action_detail if {
+test_default_action_detail_owner_match_allowed if {
 	authz.authorized with input as {
 		"username": "random-user",
 		"obj": "action-detail",
-		"params": {},
+		"params": {"owner": "random-user"},
 	}
 }
 
-test_default_action_cancel if {
+# FIND-005: the default role must not let a user view another user's action.
+test_default_action_detail_owner_mismatch_denied if {
+	not authz.authorized with input as {
+		"username": "random-user",
+		"obj": "action-detail",
+		"params": {"owner": "someone-else"},
+	}
+}
+
+test_default_action_cancel_owner_match_allowed if {
 	authz.authorized with input as {
 		"username": "random-user",
 		"obj": "action-cancel",
-		"params": {},
+		"params": {"owner": "random-user"},
+	}
+}
+
+# FIND-005: the default role must not let a user cancel another user's action.
+test_default_action_cancel_owner_mismatch_denied if {
+	not authz.authorized with input as {
+		"username": "random-user",
+		"obj": "action-cancel",
+		"params": {"owner": "someone-else"},
 	}
 }
 

--- a/packages/opa/authz/rbac_test.rego
+++ b/packages/opa/authz/rbac_test.rego
@@ -260,3 +260,22 @@ test_user_alternation_pattern_denied_partial_match if {
 		with data.users as {"user1": ["alt-team"]}
 		with data.roles as _test_roles_alternation
 }
+
+_test_roles_privileged_owner := {"support-team": [{
+	"obj": "action-detail",
+	"max_ops": null,
+	"params": {"owner": ".*"},
+}]}
+
+# A privileged role's own regex pattern (e.g. app-sre's "owner: .*" grant) is a
+# static per-role pattern, not the "$username" sentinel, and must keep matching
+# any owner regardless of who's asking.
+test_user_privileged_owner_pattern_allows_any_owner if {
+	authz.authorized with input as {
+		"username": "support-user",
+		"obj": "action-detail",
+		"params": {"owner": "someone-else"},
+	}
+		with data.users as {"support-user": ["support-team"]}
+		with data.roles as _test_roles_privileged_owner
+}


### PR DESCRIPTION
## Summary

Security audit finding FIND-005 (Project Glasswing): any authenticated user could view (`action-detail`) or cancel (`action-cancel`) any other user's action — the default OPA role granted both with `params: {}` (no constraint), and the FastAPI handlers looked the action up by ID only, with no ownership check.

- `packages/opa/authz/rbac.rego`: `valid_params` gains a `"$username"` sentinel meaning "must equal the caller's own username" — used only by the default role's new `owner` constraint. A privileged role's own static regex (e.g. app-sre's upcoming `owner: .*` grant) is untouched.
- `packages/opa/authz/default_roles.yml`: default role's `action-detail`/`action-cancel` params change from `{}` to `{"owner": "$username"}`.
- `packages/automated_actions/automated_actions/auth.py`: `OPA.__call__` gains an optional `extra_params` merged into the params sent to OPA.
- `packages/automated_actions/automated_actions/api/v1/views/action.py`: new `get_authorized_action` dependency fetches the action once, passes its owner to OPA, and returns the already-fetched action to the handler (no behavior change to the existing 404-first ordering, no extra DB read). `action_detail`/`action_cancel` move to their own router since they now authorize themselves instead of the generic router-level OPA dependency.
- Also migrated scattered inline `# ruff: ignore[...]` comments in test files to `[tool.ruff.lint.per-file-ignores]` in `pyproject.toml`.

## Why app-sre keeps broader access

App-sre support staff need to retain cross-user visibility/cancel for incident response, so this can't just lock everyone to their own actions. That's handled by a companion change granting app-sre an explicit `owner: .*` argument, mirroring the existing `action-list`/`action_user: .*` precedent — see the dependent PRs below.

## Dependencies / sequencing

This PR **must be merged/deployed last**, after the following are live in production (so app-sre's grant is in place before enforcement flips on — otherwise app-sre loses action-detail/action-cancel visibility for the gap in between):
1. app-sre/qontract-schemas#1045 — adds the `action-detail`/`action-cancel` types with an `owner` argument.
2. qontract-reconcile — `compile_roles()` case to turn `owner` into `AutomatedActionsPolicy.params` (in progress, blocked on manual codegen against a live schema).
3. app-interface MR https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/200360 — grants app-sre `owner: .*` for both new types.

## Test plan

TDD throughout — rego tests written first, confirmed red against the vulnerable `params: {}`, then green after the fix:

- [x] `packages/opa`: `make test` — 29/29 rego tests pass (new: owner match/mismatch for the default role, a privileged-role-shaped `owner: .*` regression test), `regal lint` clean.
- [x] `packages/automated_actions`: `uv run pytest` — 99/99 pass (new: `extra_params` merging in `test_opa.py`, owner match/deny through the real dependency chain in `test_action.py`). `ruff check`, `ruff format --check`, `mypy` all clean.

Jira: APPSRE-14974