### PR TITLE
fix(openshift): split shared secret into per-component secrets

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -24,8 +24,73 @@ objects:
     AA_DEBUG: "${AA_DEBUG}"
     AA_ROOT_PATH: "${AA_ROOT_PATH}"
     AA_URL: "${AA_URL}"
+    AA_ENVIRONMENT: "${AA_ENVIRONMENT}"
+    AA_VAULT_SERVER_URL: "${AA_VAULT_SERVER_URL}"
+    AA_QONTRACT_SERVER_URL: "${AA_QONTRACT_SERVER_URL}"
     OPA_ACTION_API_URL: "http://automated-actions:${AA_APP_PORT}/api/v1"
     OPA_MAX_AGE_MINUTES: "60"
+
+# -------- SECRETS ----------
+# One Secret per component so a compromised container only exposes the
+# credentials it actually uses (FIND-010). automated-actions-secret (built
+# separately by app-interface, see resources/services/automated-actions/
+# secrets.yaml.j2) still carries AA_BROKER_URL, which needs the SQS access
+# key/secret composed into a URL and can't be expressed as a plain parameter.
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    annotations:
+      qontract.recycle: "true"
+    labels:
+      app.kubernetes.io/name: automated-actions
+    name: automated-actions-api-secret
+  type: Opaque
+  stringData:
+    AA_OIDC_CLIENT_ID: "${AA_OIDC_CLIENT_ID}"
+    AA_OIDC_CLIENT_SECRET: "${AA_OIDC_CLIENT_SECRET}"
+    AA_SESSION_SECRET: "${AA_SESSION_SECRET}"
+    AA_TOKEN_SECRET: "${AA_TOKEN_SECRET}"
+    AA_DYNAMODB_URL: "${AA_DYNAMODB_URL}"
+    AA_DYNAMODB_AWS_REGION: "${AA_DYNAMODB_AWS_REGION}"
+    AA_DYNAMODB_AWS_ACCESS_KEY_ID: "${AA_DYNAMODB_AWS_ACCESS_KEY_ID}"
+    AA_DYNAMODB_AWS_SECRET_ACCESS_KEY: "${AA_DYNAMODB_AWS_SECRET_ACCESS_KEY}"
+    AA_SQS_URL: "${AA_SQS_URL}"
+    AA_BROKER_AWS_REGION: "${AA_BROKER_AWS_REGION}"
+    AA_BROKER_AWS_ACCESS_KEY_ID: "${AA_BROKER_AWS_ACCESS_KEY_ID}"
+    AA_BROKER_AWS_SECRET_ACCESS_KEY: "${AA_BROKER_AWS_SECRET_ACCESS_KEY}"
+
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    annotations:
+      qontract.recycle: "true"
+    labels:
+      app.kubernetes.io/name: automated-actions
+    name: automated-actions-worker-secret
+  type: Opaque
+  stringData:
+    AA_DYNAMODB_URL: "${AA_DYNAMODB_URL}"
+    AA_DYNAMODB_AWS_REGION: "${AA_DYNAMODB_AWS_REGION}"
+    AA_DYNAMODB_AWS_ACCESS_KEY_ID: "${AA_DYNAMODB_AWS_ACCESS_KEY_ID}"
+    AA_DYNAMODB_AWS_SECRET_ACCESS_KEY: "${AA_DYNAMODB_AWS_SECRET_ACCESS_KEY}"
+    AA_SQS_URL: "${AA_SQS_URL}"
+    AA_BROKER_AWS_REGION: "${AA_BROKER_AWS_REGION}"
+    AA_BROKER_AWS_ACCESS_KEY_ID: "${AA_BROKER_AWS_ACCESS_KEY_ID}"
+    AA_BROKER_AWS_SECRET_ACCESS_KEY: "${AA_BROKER_AWS_SECRET_ACCESS_KEY}"
+    AA_VAULT_ROLE_ID: "${AA_VAULT_ROLE_ID}"
+    AA_VAULT_SECRET_ID: "${AA_VAULT_SECRET_ID}"
+
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    annotations:
+      qontract.recycle: "true"
+    labels:
+      app.kubernetes.io/name: automated-actions
+    name: automated-actions-opa-secret
+  type: Opaque
+  stringData:
+    OPA_ACTION_API_TOKEN: "${OPA_ACTION_API_TOKEN}"
 
 # ------- API DEPLOYMENT --------------------
 - apiVersion: policy/v1
@@ -99,6 +164,9 @@ objects:
             value: "${AA_APP_PORT}"
           envFrom:
           - secretRef:
+              name: automated-actions-api-secret
+              optional: true
+          - secretRef:
               name: automated-actions-secret
               optional: true
           - configMapRef:
@@ -160,7 +228,7 @@ objects:
           - /policies # app-interface roles
           envFrom:
           - secretRef:
-              name: automated-actions-secret
+              name: automated-actions-opa-secret
               optional: true
           - configMapRef:
               name: automated-actions-config
@@ -304,6 +372,9 @@ objects:
             value: /worker-temp-dir
           envFrom:
           - secretRef:
+              name: automated-actions-worker-secret
+              optional: true
+          - secretRef:
               name: automated-actions-secret
               optional: true
           - configMapRef:
@@ -412,6 +483,20 @@ parameters:
   description: URL of the API
   required: true
 
+- name: AA_ENVIRONMENT
+  description: Deployment environment (used e.g. in the DynamoDB table name)
+  required: true
+
+- name: AA_VAULT_SERVER_URL
+  description: Vault server URL
+  value: "https://vault.devshift.net"
+  required: true
+
+- name: AA_QONTRACT_SERVER_URL
+  description: qontract-server GraphQL URL
+  value: "https://app-interface.apps.rosa.appsrep09ue1.03r5.p3.openshiftapps.com/graphql"
+  required: true
+
 ## Api Pod limits
 - name: AA_API_REPLICAS
   description: Web replicas
@@ -480,4 +565,67 @@ parameters:
 - name: AA_OPA_CPU_REQUESTS
   description: OPA cpu requests
   value: "100m"
+  required: true
+
+# Secrets, provisioned via app-interface secretParameters - split per component
+# so a compromised container only exposes the credentials it uses (FIND-010,
+# APPSRE-14977). See the Secret objects above for which component uses which.
+- name: AA_OIDC_CLIENT_ID
+  description: OIDC client ID
+  required: true
+
+- name: AA_OIDC_CLIENT_SECRET
+  description: OIDC client secret
+  required: true
+
+- name: AA_SESSION_SECRET
+  description: Session signing secret
+  required: true
+
+- name: AA_TOKEN_SECRET
+  description: Bearer token signing secret
+  required: true
+
+- name: AA_DYNAMODB_URL
+  description: DynamoDB endpoint URL
+  required: true
+
+- name: AA_DYNAMODB_AWS_REGION
+  description: DynamoDB AWS region
+  required: true
+
+- name: AA_DYNAMODB_AWS_ACCESS_KEY_ID
+  description: DynamoDB AWS access key ID
+  required: true
+
+- name: AA_DYNAMODB_AWS_SECRET_ACCESS_KEY
+  description: DynamoDB AWS secret access key
+  required: true
+
+- name: AA_SQS_URL
+  description: SQS queue URL used as the Celery broker
+  required: true
+
+- name: AA_BROKER_AWS_REGION
+  description: Celery broker (SQS) AWS region
+  required: true
+
+- name: AA_BROKER_AWS_ACCESS_KEY_ID
+  description: Celery broker (SQS) AWS access key ID
+  required: true
+
+- name: AA_BROKER_AWS_SECRET_ACCESS_KEY
+  description: Celery broker (SQS) AWS secret access key
+  required: true
+
+- name: AA_VAULT_ROLE_ID
+  description: Vault AppRole role ID (worker only)
+  required: true
+
+- name: AA_VAULT_SECRET_ID
+  description: Vault AppRole secret ID (worker only)
+  required: true
+
+- name: OPA_ACTION_API_TOKEN
+  description: Bearer token OPA uses to call back into the API for rate limiting (opa sidecar only)
   required: true

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -489,12 +489,10 @@ parameters:
 
 - name: AA_VAULT_SERVER_URL
   description: Vault server URL
-  value: "https://vault.devshift.net"
   required: true
 
 - name: AA_QONTRACT_SERVER_URL
   description: qontract-server GraphQL URL
-  value: "https://app-interface.apps.rosa.appsrep09ue1.03r5.p3.openshiftapps.com/graphql"
   required: true
 
 ## Api Pod limits


### PR DESCRIPTION
## Summary

APPSRE-14977: all three components (api, worker, opa sidecar) loaded the same `automated-actions-secret` via `envFrom`, so compromising the lowest-privileged component (opa) exposed the full credential set — OIDC/session/token secrets, Vault AppRole credentials, and AWS keys it never uses.

Each component now gets its own `Secret`, built directly by `openshift/template.yaml` from new template parameters — mirroring the pattern already used by `glitchtip` (secret values passed in via SaaS `secretParameters`, Secret objects built by the template itself) rather than a single Jinja2-rendered Secret manifest from app-interface:

- **`automated-actions-api-secret`**: OIDC client id/secret, session secret, token secret, DynamoDB creds, broker/SQS creds
- **`automated-actions-worker-secret`**: DynamoDB creds, broker/SQS creds, Vault AppRole role/secret id
- **`automated-actions-opa-secret`**: `OPA_ACTION_API_TOKEN` only

Note DynamoDB and broker/SQS credentials are referenced by **both** api and worker secrets — not leftover sharing, but because both components genuinely need them: the API also enqueues Celery tasks (`.apply_async()` in `api/v1/views/{openshift,external_resource,no_op}.py`), and both read/write `Action` records in DynamoDB. Only OIDC/session/token (API-only) and Vault AppRole (worker-only) are truly exclusive to one component.

`AA_ENVIRONMENT` moves into the already-shared `automated-actions-config` ConfigMap instead of the secret. `AA_VAULT_SERVER_URL`/`AA_QONTRACT_SERVER_URL` are required parameters with **no default** (not even an empty string — `oc process` treats `required: true` + `value: ""` as still unspecified) — this repo is public, so their real values must only ever live in app-interface, never as a default here.

## Companion app-interface MR

https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/200401 adds the `secretParameters` this template needs and keeps `resources/services/automated-actions/secrets.yaml.j2` fully intact for now (see sequencing below).

## Sequencing (important)

qontract-reconcile's `oc process` call always includes `--ignore-unknown-parameters` (`reconcile/utils/oc.py`), so extra `secretParameters` are harmless against a template that doesn't declare them yet — but a `required: true` parameter with **no value supplied** still hard-fails processing. So:

1. **Merge the app-interface MR first** (purely additive: new `secretParameters`, `secrets.yaml.j2` untouched) — inert against this repo's currently-deployed template.
2. **Merge this PR second** — by then app-interface already supplies everything the new template needs.
3. A **final follow-up app-interface MR** (later, once this is deployed everywhere) trims `secrets.yaml.j2` down to just `AA_BROKER_URL` (the one value that still needs Jinja2 composition).

## Test plan

- [x] `oc process -f openshift/template.yaml --param-file=<all-required-params> --local -o yaml` — processes cleanly; verified each container's `envFrom` references exactly the right secret(s) (web → api-secret + broker-url; opa → opa-secret only; worker → worker-secret + broker-url).
- [x] Verified `required: true` with no `value:` behaves correctly once the companion MR supplies `AA_VAULT_SERVER_URL`/`AA_QONTRACT_SERVER_URL`.

Jira: APPSRE-14977