### PR TITLE
fix(cli): persist the Kerberos-auth cookie jar to disk

### DIFF
--- a/packages/automated_actions_cli/automated_actions_cli/cli.py
+++ b/packages/automated_actions_cli/automated_actions_cli/cli.py
@@ -170,6 +170,9 @@ def main(  # ruff: ignore[complex-structure, too-many-branches]
         cookiejar = MozillaCookieJar(filename=config.cookies_file)
         with contextlib.suppress(FileNotFoundError):
             cookiejar.load()
+        # persist the session cookie set during login so subsequent CLI
+        # invocations don't have to redo the full SSO redirect/token exchange
+        atexit.register(cookiejar.save, ignore_discard=True)
 
         aa_client.configure(
             config=Config(

--- a/packages/automated_actions_cli/pyproject.toml
+++ b/packages/automated_actions_cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "automated-actions-cli"
-version = "0.4.0"
+version = "0.4.1"
 description = "Automated Actions Client"
 authors = [
     # Feel free to add or change authors

--- a/packages/automated_actions_cli/tests/test_cli.py
+++ b/packages/automated_actions_cli/tests/test_cli.py
@@ -1,13 +1,23 @@
+from http.cookiejar import MozillaCookieJar
+from typing import TYPE_CHECKING
+
+import click
 import pytest
 from automated_actions_client.schemas import ActionSchemaOut, ActionStatus
 from typer.core import TyperCommand, TyperGroup, TyperOption
 from typer.main import get_command
 
+from automated_actions_cli import cli
 from automated_actions_cli.cli import (
     _get_help_panel,  # ruff: ignore[import-private-name]
     _serialize_result,  # ruff: ignore[import-private-name]
     app,
+    main,
 )
+from automated_actions_cli.config import Config
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 _cmd = get_command(app)
 assert isinstance(_cmd, TyperGroup)
@@ -221,3 +231,64 @@ def test_openshift_workload_delete_params() -> None:
         "name",
         "api_version",
     }
+
+
+# --- Kerberos cookie jar persistence ---
+
+
+def _run_main_with_kerberos_auth(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Invoke main() through the Kerberos auth branch with all I/O stubbed out.
+
+    Registers `atexit.register`'d callbacks to run immediately (instead of at
+    real process exit) so their effect can be asserted within the test.
+    """
+    monkeypatch.delenv("AA_TOKEN", raising=False)
+    monkeypatch.setattr(cli, "kerberos_available", lambda: True)
+    monkeypatch.setattr(cli, "kinit", lambda: None)
+    monkeypatch.setattr(cli, "me", lambda: None)
+    monkeypatch.setattr(cli.atexit, "register", lambda func, *a, **kw: func(*a, **kw))
+    ctx = click.Context(click.Command("test"))
+    main(ctx, quiet=True)  # type: ignore[call-arg]
+
+
+def test_kerberos_auth_persists_cookie_jar_to_disk(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A CLI process authenticating via Kerberos must save the session cookie.
+
+    Without this, every separate CLI invocation starts from an empty cookie
+    jar and has to redo the full SSO redirect/token-exchange dance, even
+    though the server-side session cookie is still valid.
+    """
+    cookies_file = tmp_path / "cookies.txt"
+    monkeypatch.setattr(Config, "cookies_file", cookies_file)
+
+    _run_main_with_kerberos_auth(monkeypatch)
+
+    assert cookies_file.exists()
+
+
+def test_kerberos_auth_saves_cookie_jar_ignoring_discard(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The jar must be saved with ignore_discard=True.
+
+    Otherwise a cookie that ever comes back without an explicit expiry (a
+    true browser-session cookie) would silently be dropped from the file.
+    """
+    cookies_file = tmp_path / "cookies.txt"
+    monkeypatch.setattr(Config, "cookies_file", cookies_file)
+
+    save_calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
+    original_save = MozillaCookieJar.save
+
+    def spy_save(self: MozillaCookieJar, *args: object, **kwargs: object) -> None:
+        save_calls.append((args, kwargs))
+        original_save(self, *args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(MozillaCookieJar, "save", spy_save)
+
+    _run_main_with_kerberos_auth(monkeypatch)
+
+    assert len(save_calls) == 1
+    assert save_calls[0][1].get("ignore_discard") is True

--- a/packages/automated_actions_cli/tests/test_cli.py
+++ b/packages/automated_actions_cli/tests/test_cli.py
@@ -1,8 +1,8 @@
 from http.cookiejar import MozillaCookieJar
 from typing import TYPE_CHECKING
 
-import click
 import pytest
+import typer
 from automated_actions_client.schemas import ActionSchemaOut, ActionStatus
 from typer.core import TyperCommand, TyperGroup, TyperOption
 from typer.main import get_command
@@ -247,7 +247,7 @@ def _run_main_with_kerberos_auth(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(cli, "kinit", lambda: None)
     monkeypatch.setattr(cli, "me", lambda: None)
     monkeypatch.setattr(cli.atexit, "register", lambda func, *a, **kw: func(*a, **kw))
-    ctx = click.Context(click.Command("test"))
+    ctx = typer.Context(click_app)
     main(ctx, quiet=True)  # type: ignore[call-arg]
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -261,7 +261,7 @@ dev = [
 
 [[package]]
 name = "automated-actions-cli"
-version = "0.4.0"
+version = "0.4.1"
 source = { editable = "packages/automated_actions_cli" }
 dependencies = [
     { name = "appdirs" },


### PR DESCRIPTION
## Summary

The CLI's `MozillaCookieJar` was loaded from `cookies.txt` on startup but never saved back to disk, so the session cookie set during the OIDC/SSO login flow only ever lived in the in-process httpx2 client.

Every separate CLI invocation therefore started from an empty/stale cookie jar and had to redo the entire login handshake (redirect → Kerberos ticket check → token exchange → userinfo → OPA), even though the server-side session cookie (which does carry an explicit expiry, see `auth.py`'s `set_cookie(..., expires=self.session_timeout_secs)`) was still valid.

## Fix

- `packages/automated_actions_cli/automated_actions_cli/cli.py`: register `atexit.register(cookiejar.save, ignore_discard=True)` right after loading the jar, matching the pattern already used for other `atexit` cleanup in `main()`.
- Bumped `automated-actions-cli` to `0.4.1` and regenerated `uv.lock`.

## Test plan

TDD: wrote two tests against `main()`'s Kerberos auth branch first, confirmed both failed against the unfixed code, then implemented the fix and confirmed green.

- [x] `test_kerberos_auth_persists_cookie_jar_to_disk` — cookie jar file exists on disk after a Kerberos-authenticated run
- [x] `test_kerberos_auth_saves_cookie_jar_ignoring_discard` — `save()` is called with `ignore_discard=True`
- [x] `packages/automated_actions_cli`: `uv run pytest` (38/38), `ruff check`, `ruff format --check`, `mypy` all clean