### PR TITLE
fix(security): disable SA token automount on api/opa and add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,14 @@
+# Security Policy
+
+This repository contains the source code for the Red Hat AppSRE Automated Actions service.
+
+## Reporting a Vulnerability
+
+Please do **not** report security vulnerabilities through public GitHub issues or pull requests.
+
+To report a security issue in this repository or the AppSRE-managed Automated Actions deployment, contact Red Hat Product Security:
+
+- Email: [secalert@redhat.com](mailto:secalert@redhat.com)
+- PGP key and additional details: <https://access.redhat.com/security/team/contact>
+
+Red Hat Product Security will acknowledge your report and coordinate remediation and disclosure.

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -46,6 +46,8 @@ objects:
     labels:
       app.kubernetes.io/component: api
       app.kubernetes.io/name: automated-actions
+  # api and its opa sidecar never call the in-cluster K8s API (FIND-009 / APPSRE-14976).
+  automountServiceAccountToken: false
 
 - apiVersion: apps/v1
   kind: Deployment


### PR DESCRIPTION
## Summary

Addresses two findings from the Glasswing AI security audit:

- **[APPSRE-14976](https://redhat.atlassian.net/browse/APPSRE-14976) (FIND-009)**: The `api` Deployment (which also runs the `opa` sidecar) never calls the in-cluster Kubernetes API, yet its ServiceAccount didn't set `automountServiceAccountToken: false`. Fixed by disabling automount on the `automated-actions-api` ServiceAccount. The `automated-actions-worker` ServiceAccount is left unchanged since the worker relies on its token for Vault's Kubernetes auth method.
- **[APPSRE-14978](https://redhat.atlassian.net/browse/APPSRE-14978) (FIND-011)**: Adds `SECURITY.md` with the Red Hat Product Security contact, modeled on [app-sre/glitchtip#900](https://github.com/app-sre/glitchtip/pull/900).

## Explicitly out of scope

FIND-011 also flagged two other items, which are **not** addressed here:

- **Missing NetworkPolicy objects** — OpenShift's default namespace-scoped NetworkPolicy already restricts traffic to pods within the namespace; the `opa` sidecar is also already loopback-only (see the existing FIND-001 fix in `template.yaml`).
- **`IMAGE_TAG` defaulting to `latest`** — app-interface's SaaS deployment always overrides `IMAGE_TAG` with a pinned revision SHA at deploy time (via Konflux), so the in-repo default is never actually used in practice.

## Test plan

- [x] `openshift/template.yaml` parses as valid YAML
- [x] `rh-pre-commit` hook passed on commit
- [ ] Confirm the OpenShift template still applies cleanly (`oc process`) in CI